### PR TITLE
Pass manage_packages to mcollective::client::base

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,11 +137,12 @@ class mcollective(
 
   if $client_real {
     class { 'mcollective::client::base':
-      version     => $version_real,
-      config      => $client_config_real,
-      config_file => $client_config_file_real,
-      require     => Anchor['mcollective::begin'],
-      before      => Anchor['mcollective::end'],
+      version         => $version_real,
+      config          => $client_config_real,
+      config_file     => $client_config_file_real,
+      manage_packages => $manage_packages,
+      require         => Anchor['mcollective::begin'],
+      before          => Anchor['mcollective::end'],
     }
   }
 


### PR DESCRIPTION
mcollective::client::base requires the manage_packages parameter.  However it wasn't being passed in the mcollective class
