### PR TITLE
Fix for RHEL case in manifests/server/package.pp

### DIFF
--- a/manifests/server/package.pp
+++ b/manifests/server/package.pp
@@ -31,7 +31,7 @@ class mcollective::server::package(
         before  => Anchor['mcollective::server::package::end'],
       }
     }
-    rhel,centos,oel: {
+    redhat,centos,oel: {
       class { 'mcollective::server::package::redhat':
         version => $version,
         require => Anchor['mcollective::server::package::begin'],


### PR DESCRIPTION
The operatingsystem fact for RHEL is 'redhat'. This causes packages not to be installed under RHEL.
