### PR TITLE
Make stomp user and password configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,8 @@ class mcollective(
   $client_config_file   = '/etc/mcollective/client.cfg',
   $stomp_server         = $mcollective::params::stomp_server,
   $stomp_port           = '61613',
+  $stomp_user           = $mcollective::params::stomp_user,
+  $stomp_passwd         = $mcollective::params::stomp_passwd,
   $mc_security_provider = $mcollective::params::mc_security_provider,
   $mc_security_psk      = $mcollective::params::mc_security_psk,
   $fact_source          = 'facter',


### PR DESCRIPTION
Allow the user of the mcollective class to explicitly set the stomp username and password to use for connecting to the stomp server.
