### PR TITLE
fix the default class mcollective $stomp_port parameter value.  The curr...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,7 +64,7 @@ class mcollective(
   $client_config        = 'UNSET',
   $client_config_file   = '/etc/mcollective/client.cfg',
   $stomp_server         = $mcollective::params::stomp_server,
-  $stomp_port           = '61613',
+  $stomp_port           = '6163',
   $mc_security_provider = $mcollective::params::mc_security_provider,
   $mc_security_psk      = $mcollective::params::mc_security_psk,
   $fact_source          = 'facter',


### PR DESCRIPTION
...ent value of 61613 appears to be a typo.  The default port should be 6163.
