### PR TITLE
fix typo on stomp password variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,7 +151,7 @@ class mcollective(
   if $stomp_pool == 'UNSET' {
     $stomp_pool_real = {
       pool1 => { host1 => $stomp_server, port1 => $stomp_port, user1 => $stomp_user,
-                 passwd1 => $stomp_passwd  }
+                 password1 => $stomp_passwd  }
     }
   }
   else {


### PR DESCRIPTION
changed from passwd1 to password for the stomp variable
