### PR TITLE
fix typo in generated client/server configs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,7 +151,7 @@ class mcollective(
   if $stomp_pool == 'UNSET' {
     $stomp_pool_real = {
       pool1 => { host1 => $stomp_server, port1 => $stomp_port, user1 => $stomp_user,
-                 passwd1 => $stomp_passwd  }
+                 password1 => $stomp_passwd  }
     }
   }
   else {


### PR DESCRIPTION
when no `stomp_pool` parameter is passed, the automatically generated
password config entries need to be `plugin.stomp.pool.password1`, not
`plugin.stomp.pool.passwd1`.
