### PR TITLE
sorting hashes to reduce config change noise

### DIFF
--- a/templates/client.cfg.erb
+++ b/templates/client.cfg.erb
@@ -12,8 +12,8 @@ plugin.psk       = <%= mc_security_psk_real %>
 # Middleware
 connector              = <%= connector %>
 plugin.stomp.pool.size = <%= stomp_pool_size %>
-<% stomp_pool_real.each do |pool,configs| -%>
-<% configs.each do |key,value| -%>
+<% stomp_pool_real.sort.each do |pool,configs| -%>
+<% configs.sort.each do |key,value| -%>
 plugin.stomp.pool.<%= key -%> = <%= value %>
 <% end -%>
 <% end -%>

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -19,13 +19,13 @@ registration     = Meta
 # Middleware
 connector              = <%= connector %>
 plugin.stomp.pool.size = <%= stomp_pool_size %>
-<% stomp_pool_real.each do |pool,configs| -%>
-<% configs.each do |key,value| -%>
+<% stomp_pool_real.sort.each do |pool,configs| -%>
+<% configs.sort.each do |key,value| -%>
 plugin.stomp.pool.<%= key -%> = <%= value %>
 <% end -%>
 <% end -%>
 
-<% plugin_params.each do |param,value| -%>
+<% plugin_params.sort.each do |param,value| -%>
 plugin.<%= param -%> = <%= value %>
 <% end -%>
 


### PR DESCRIPTION
Repeatedly iterating over the same hash can produce different results
each time, since hash element order is not guaranteed.  Each iteration
produces a different config file, which causes a needless restart of
mcollective.

One fix is to sort the keys of each config hash inside the templates.
