### PR TITLE
Minor fix to correct issues noted in commit puppetlabs/puppetlabs-mcollective@cc7f3ec78c

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,7 +100,7 @@ class mcollective(
   $collectives          = 'mcollective',
   $connector            = 'stomp',
   $classesfile          = '/var/lib/puppet/state/classes.txt',
-  $stomp_pool           = {},
+  $stomp_pool           = 'UNSET',
   $stomp_server         = $mcollective::params::stomp_server,
   $stomp_port           = $mcollective::params::stomp_port,
   $stomp_user           = $mcollective::params::stomp_user,


### PR DESCRIPTION
Without this fix, the module throws this error:
"" is not a Hash.  It looks to be a String at .../modules/mcollective/manifests/init.pp:159
