### PR TITLE
Enable service when supported

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -35,6 +35,13 @@ class mcollective::server::service(
     ensure    => running,
     name      => $mc_service_name,
     hasstatus => true,
+    enable    => $osfamily ? {
+        base    => false,
+        init    => false,
+        service => false,
+        src     => false,
+        default => true,
+    },
     start     => $mc_service_start_real,
     stop      => $mc_service_stop_real,
   }


### PR DESCRIPTION
As far as I could tell, if enable == false, then enable() isn't called--so service types on osfamilies not supporting enableable should not error out on puppet runs.
