### PR TITLE
Fix default log level to a valid value

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,7 @@ class mcollective::params {
   $mc_main_collective   = 'mcollective'
   $mc_collectives       = ''
   $mc_logfile           = '/var/log/mcollective.log'
-  $mc_loglevel          = 'log'
+  $mc_loglevel          = 'info'
   $mc_daemonize         = '1'
   $mc_security_provider = 'psk'
   $mc_security_psk      = 'changemeplease'


### PR DESCRIPTION
Fixes start failure under mcollective 2.3.x:

```
/usr/lib/ruby/site_ruby/1.8/mcollective/logger/base.rb:26:in `>=': comparison of Fixnum with nil failed (ArgumentError)
    from /usr/lib/ruby/site_ruby/1.8/mcollective/logger/base.rb:26:in `should_log?'
    from /usr/lib/ruby/site_ruby/1.8/mcollective/log.rb:52:in `config_and_check_level'
    from /usr/lib/ruby/site_ruby/1.8/mcollective/log.rb:106:in `log'
    from /usr/lib/ruby/site_ruby/1.8/mcollective/log.rb:36:in `error'
    from /usr/lib/ruby/site_ruby/1.8/mcollective/pluginmanager.rb:171:in `loadclass'
    from /usr/lib/ruby/site_ruby/1.8/mcollective/config.rb:142:in `loadconfig'
    from /usr/sbin/mcollectived:29
```
