### PR TITLE
Prefix variables with @ to silence warnings

### DIFF
--- a/templates/client.cfg.erb
+++ b/templates/client.cfg.erb
@@ -1,19 +1,19 @@
 # Basic stuff
-topicprefix     = <%= mc_topicprefix %>
-main_collective = <%= main_collective %>
-collectives     = <%= collectives %>
-libdir          = <%= mc_libdir %>
-loglevel        = <%= mc_loglevel %>
+topicprefix     = <%= @mc_topicprefix %>
+main_collective = <%= @main_collective %>
+collectives     = <%= @collectives %>
+libdir          = <%= @mc_libdir %>
+loglevel        = <%= @mc_loglevel %>
 
 # Plugins
-securityprovider = <%= mc_security_provider_real %>
-plugin.psk       = <%= mc_security_psk_real %>
+securityprovider = <%= @mc_security_provider_real %>
+plugin.psk       = <%= @mc_security_psk_real %>
 
 # Middleware
-connector              = <%= connector %>
-plugin.stomp.pool.size = <%= stomp_pool_size %>
-<% stomp_pool_real.sort.each do |pool,configs| -%>
-<% configs.sort.each do |key,value| -%>
+connector              = <%= @connector %>
+plugin.stomp.pool.size = <%= @stomp_pool_size %>
+<% @stomp_pool_real.sort.each do |pool,configs| -%>
+<% @configs.sort.each do |key,value| -%>
 plugin.stomp.pool.<%= key -%> = <%= value %>
 <% end -%>
 <% end -%>

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -1,39 +1,39 @@
 # Basic stuff
-topicprefix     = <%= mc_topicprefix %>
-main_collective = <%= main_collective %>
-collectives     = <%= collectives %>
-libdir          = <%= mc_libdir %>
-logfile         = <%= mc_logfile %>
-loglevel        = <%= mc_loglevel %>
-daemonize       = <%= mc_daemonize %>
-classesfile     = <%= classesfile %>
+topicprefix     = <%= @mc_topicprefix %>
+main_collective = <%= @main_collective %>
+collectives     = <%= @collectives %>
+libdir          = <%= @mc_libdir %>
+logfile         = <%= @mc_logfile %>
+loglevel        = <%= @mc_loglevel %>
+daemonize       = <%= @mc_daemonize %>
+classesfile     = <%= @classesfile %>
 
 # Plugins
-securityprovider = <%= mc_security_provider_real %>
-plugin.psk       = <%= mc_security_psk_real %>
+securityprovider = <%= @mc_security_provider_real %>
+plugin.psk       = <%= @mc_security_psk_real %>
 
 # Registration
 registerinterval = 300
 registration     = Meta
 
 # Middleware
-connector              = <%= connector %>
-plugin.stomp.pool.size = <%= stomp_pool_size %>
-<% stomp_pool_real.sort.each do |pool,configs| -%>
+connector              = <%= @connector %>
+plugin.stomp.pool.size = <%= @stomp_pool_size %>
+<% @stomp_pool_real.sort.each do |pool,configs| -%>
 <% configs.sort.each do |key,value| -%>
 plugin.stomp.pool.<%= key -%> = <%= value %>
 <% end -%>
 <% end -%>
 
-<% plugin_params.sort.each do |param,value| -%>
+<% @plugin_params.sort.each do |param,value| -%>
 plugin.<%= param -%> = <%= value %>
 <% end -%>
 
 # NRPE
-plugin.nrpe.conf_dir  = <%= nrpe_dir_real %>
+plugin.nrpe.conf_dir  = <%= @nrpe_dir_real %>
 
 # Facts
-factsource = <%= fact_source %>
-<% if fact_source == 'yaml' -%>
-plugin.yaml = <%= yaml_facter_source %>
+factsource = <%= @fact_source %>
+<% if @fact_source == 'yaml' -%>
+plugin.yaml = <%= @yaml_facter_source %>
 <% end -%>


### PR DESCRIPTION
Fix template warnings in recent puppet versions by prefixing local scope variables with '@'
