### PR TITLE
Set identify so that debian and ubuntu show the same behavior

### DIFF
--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -7,6 +7,7 @@ logfile         = <%= mc_logfile %>
 loglevel        = <%= mc_loglevel %>
 daemonize       = <%= mc_daemonize %>
 classesfile     = <%= classesfile %>
+identity        = <%= fqdn %>
 
 # Plugins
 securityprovider = <%= mc_security_provider_real %>


### PR DESCRIPTION
After setting up my mcollective my debian hosts showed fqdn and my ubuntu hosts showed hostname as identifier. This not only is ugly but also makes selecting the hosts a pain. So i added this line to force them to show the fqdn.
