### PR TITLE
set default value to "UNSET" so that it is recognized later

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,7 +100,7 @@ class mcollective(
   $collectives          = 'mcollective',
   $connector            = 'stomp',
   $classesfile          = '/var/lib/puppet/state/classes.txt',
-  $stomp_pool           = {},
+  $stomp_pool           = 'UNSET',
   $stomp_server         = $mcollective::params::stomp_server,
   $stomp_port           = $mcollective::params::stomp_port,
   $stomp_user           = $mcollective::params::stomp_user,


### PR DESCRIPTION
When providing only one stomp_server the default stomp_pool value must be 'UNSET' so that the stomp_pool is created correctly.
