### PR TITLE
(#56) notify service to restart on plugin install

### DIFF
--- a/manifests/common/config.pp
+++ b/manifests/common/config.pp
@@ -15,6 +15,11 @@ class mcollective::common::config {
     sourceselect => 'all',
   }
 
+  if $mcollective::server {
+    # if we have a server install, reload when the plugins change
+    File[$mcollective::site_libdir] ~> Class['mcollective::server::service']
+  }
+
   datacat_collector { 'mcollective::site_libdir':
     before          => File[$mcollective::site_libdir],
     target_resource => File[$mcollective::site_libdir],

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -4,14 +4,21 @@ define mcollective::plugin(
   $package = false,
   $type = 'agent',
   $has_client = true,
-  # $client is to allow for unit testing, and considered a private
-  # parameter
+  # $client and $server are to allow for unit testing, and are considered private
+  # parameters
   $client = $mcollective::client,
+  $server = $mcollective::server,
 ) {
   if $package {
-    # install from a package named "mcollective-${name}-${type}
-    package { "mcollective-${name}-${type}":
+    # install from a package named "mcollective-${name}-${type}"
+    $package_name = "mcollective-${name}-${type}"
+    package { $package_name:
       ensure => 'present',
+    }
+
+    if $server {
+      # set up a notification if we know we're managing a server
+      Package[$package_name] ~> Class['mcollective::server::service']
     }
 
     # install the client package if we're installing on a $mcollective::client


### PR DESCRIPTION
See if we're managing a server, and if so set notifications from the package
resource or File[$mcollective::site_libdir].

This isn't excercised by the rspec-puppet tests, as there's no way
to test for resource relationships currently with rspec-puppet.
Maybe if rodjek/rspec-puppet#106 were merged.
