### PR TITLE
(#66) Stop puppet internals leaking into facts.yaml

### DIFF
--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -112,12 +112,12 @@ describe 'mcollective' do
       end
 
       context 'yaml' do
-        let(:facts) { { :osfamily => 'RedHat', :number_of_cores => 42 } }
+        let(:facts) { { :osfamily => 'RedHat', :number_of_cores => "42", :non_string => 69 } }
         it { should contain_file('/etc/mcollective/facts.yaml') }
         it { should contain_file('/etc/mcollective/facts.yaml').with_content(/^  osfamily: RedHat/) }
-        it { should contain_file('/etc/mcollective/facts.yaml').with_content(/^  number_of_cores: 42/) }
+        it { should contain_file('/etc/mcollective/facts.yaml').with_content(/^  number_of_cores: "42"/) }
         it 'should be alpha-sorted' do
-          should contain_file('/etc/mcollective/facts.yaml').with_content(/^  number_of_cores:.*?^  osfamily:/m)
+          should contain_file('/etc/mcollective/facts.yaml').with_content(/^  number_of_cores:.*?^  osfamily: RedHat$/m)
         end
 
         describe '#yaml_fact_path' do

--- a/templates/facts.yaml.erb
+++ b/templates/facts.yaml.erb
@@ -1,6 +1,8 @@
 <%=
-    # remove dynamic facts
-    obj = scope.to_hash.reject {|k,v| k.to_s =~ /^(uptime.*|rubysitedir|_timestamp|memoryfree.*|swapfree.*|title|name|caller_module_name|module_name)$/ }
+    # remove dynamic facts and non-string values
+    obj = scope.to_hash.reject { |k,v|
+        (k.to_s =~ /^(uptime.*|rubysitedir|_timestamp|memoryfree.*|swapfree.*|title|name|caller_module_name|module_name)$/i) || (v.class != ::String)
+    }
 
     arr = obj.sort
     out = "---\n"


### PR DESCRIPTION
Prior to this patch we'd take everything in scope that didn't have a dynamic
name.  This patch extends it to reject anything that's a Puppet internal class.

An alternate approach may be to reject anything where the value is not of class String,
but that would start to bite once structured facts become a thing.

Closes #66
