### PR TITLE
(#68) dump scope.compiler.topscope rather than scope

### DIFF
--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -119,6 +119,9 @@ describe 'mcollective' do
         it 'should be alpha-sorted' do
           should contain_file('/etc/mcollective/facts.yaml').with_content(/^  number_of_cores:.*?^  osfamily: RedHat$/m)
         end
+        it 'should not leak' do
+          should_not contain_file('/etc/mcollective/facts.yaml').with_content(/middleware_password/)
+        end
 
         describe '#yaml_fact_path' do
           it 'should default to /etc/mcollective/facts.yaml' do

--- a/templates/facts.yaml.erb
+++ b/templates/facts.yaml.erb
@@ -1,7 +1,7 @@
 <%=
     # remove dynamic facts and non-string values
-    obj = scope.to_hash.reject { |k,v|
-        (k.to_s =~ /^(uptime.*|rubysitedir|_timestamp|memoryfree.*|swapfree.*|title|name|caller_module_name|module_name)$/i) || (v.class != ::String)
+    obj = scope.compiler.topscope.to_hash.reject { |k,v|
+        (k.to_s =~ /^(uptime.*|rubysitedir|_timestamp|memoryfree.*|swapfree.*)$/i) || (v.class != ::String)
     }
 
     arr = obj.sort


### PR DESCRIPTION
This avoids the information leakage from taking whatever might be in scope of
mcollective::server::config::factsource::yaml, and instead rummages around in
the innards of the compiler to find topscope.

Approach figured out by R.I.Pienaar.

Closes #68
