### PR TITLE
(#76) use hash to build anonymous hash

### DIFF
--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -1,11 +1,8 @@
 # private define - mcollective::setting
 define mcollective::setting($setting, $value, $target, $order = '50') {
-  # The parser chokes on `data => { $setting => $value }` so help it out
-  $data = {}
-  $data[$setting] = $value
   datacat_fragment { "mcollective::setting ${title}":
     target => $target,
     order  => $order,
-    data   => $data,
+    data   => hash([ $setting, $value ]),
   }
 }


### PR DESCRIPTION
The future parser is stricter about assigning to hash elements than the old 
parser, so use hash() from puppetlabs-stdlib rather than constructing an 
anonymous hash in the puppet language.
