### PR TITLE
maint - repopulate the travis matrix of tested versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,23 @@ after_success:
   - git clone -q git://github.com/puppetlabs/ghpublisher.git .forge-release
   - .forge-release/publish
 rvm:
+  - 1.8.7
   - 1.9.3
   - 2.0.0
 env:
   matrix:
+    - PUPPET_GEM_VERSION="~> 3.0.0"
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
     - PUPPET_GEM_VERSION="~> 3.3.0"
   global:
     - PUBLISHER_LOGIN=puppetlabs
     - secure: iI91FnYPqlR7+KQBga6ujKB/3N+Wv91mvGhSdAkLl+HsncKLglH+epjXMJ4DLrv08W9msQ+u/ZA6nvAKv9sQTPb/RKx67mC56CHEHguKwCBPsVdJRVjMBseMTl+9INiG58s9uJKA3LRfGd760+WMYJUwDyh+lWTrTOmwNm4WfKI=
+matrix:
+  exclude:
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.0.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
 notifications:
   email: false


### PR DESCRIPTION
7ca85a8 dropped travis testing of 3.0, 3.1, and 3.2, and also ruby 1.8.7.

7ff5aae claims that 3.0, 3.1, and 3.2 are tested and working versions.

This commit reinstates these jobs to the travis matrix so we can have some
more confidence that the claims of 7ff5aae are substantiated.
