### PR TITLE
(#86) grant the rabbitmq admin user configure permssions

### DIFF
--- a/manifests/middleware/rabbitmq.pp
+++ b/manifests/middleware/rabbitmq.pp
@@ -66,6 +66,10 @@ class mcollective::middleware::rabbitmq {
     write_permission     => '.*',
   } ->
 
+  rabbitmq_user_permissions { "${mcollective::middleware_admin_user}@${mcollective::rabbitmq_vhost}":
+    configure_permission => '.*',
+  } ->
+
   rabbitmq_exchange { "mcollective_broadcast@${mcollective::rabbitmq_vhost}":
     ensure   => present,
     type     => 'topic',


### PR DESCRIPTION
Configure permissions are required for the user to be able to create exchanges.

Closes #86
