### PR TITLE
maint - add rabbitmq to rspec-system testing

### DIFF
--- a/.nodeset.yml
+++ b/.nodeset.yml
@@ -9,6 +9,10 @@ sets:
     nodes:
       "main.foo.vm":
         prefab: 'centos-64-x64'
+  'centos-64-x64-rabbitmq':
+    nodes:
+      "rabbitmq.foo.vm":
+        prefab: 'centos-64-x64'
   'fedora-18-x64':
     nodes:
       "main.foo.vm":

--- a/spec/fixtures/data/rabbitmq.foo.vm.json
+++ b/spec/fixtures/data/rabbitmq.foo.vm.json
@@ -1,0 +1,4 @@
+{
+    "erlang::epel_enable": "true",
+    "mcollective::connector": "rabbitmq"
+}

--- a/spec/fixtures/hiera.yaml
+++ b/spec/fixtures/hiera.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - json
+:json:
+  :datadir: /etc/puppet/data
+:hierarchy:
+  - "%{::fqdn}"
+  - common

--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -16,6 +16,12 @@ RSpec.configure do |c|
   c.before :suite do
     puppet_install
 
+    rcp(:source_path => proj_root + '/spec/fixtures/hiera.yaml',
+        :destination_path => '/etc/puppet/hiera.yaml')
+
+    rcp(:source_path => proj_root + '/spec/fixtures/data',
+        :destination_path => '/etc/puppet/data')
+
     puppet_module_install(:source => proj_root, :module_name => 'mcollective')
     puppet_module_install(:source => proj_root + '/spec/fixtures/modules/site_mcollective', :module_name => 'site_mcollective')
     puppet_module_install(:source => proj_root + '/spec/fixtures/modules/site_nagios', :module_name => 'site_nagios')
@@ -24,6 +30,7 @@ RSpec.configure do |c|
     #
     shell 'puppet module install puppetlabs/activemq'
     shell 'puppet module install puppetlabs/java_ks'
+    shell 'puppet module install puppetlabs/rabbitmq'
     shell 'puppet module install richardc/datacat'
   end
 end

--- a/spec/system/end_to_end_spec.rb
+++ b/spec/system/end_to_end_spec.rb
@@ -8,9 +8,18 @@ describe 'single node setup:' do
     its(:exit_code) { should_not eq(1) }
   end
 
+  describe 'bounce rabbitmq maybe' do
+    # rabbitmq needs a bounce to enable stomp - the rabbitmq module
+    # should probably take care of this
+    context shell('sudo service rabbitmq-server restart') do
+      # we want the command to run, we don't care what it returns
+      its(:exit_code) { should be_a_kind_of(Numeric) }
+    end
+  end
+
   describe 'root can do what they like' do
     context shell('sudo -i mco ping') do
-      its(:stdout) { should =~ /main.foo.vm/ }
+      its(:stdout) { should =~ /.foo.vm/ }
     end
 
     context shell('sudo -i mco rpc rpcutil inventory -j </dev/null') do
@@ -24,7 +33,7 @@ describe 'single node setup:' do
 
   describe 'nagios user can do limited things' do
     context shell('sudo -i -u nagios mco ping') do
-      its(:stdout) { should =~ /main.foo.vm/ }
+      its(:stdout) { should =~ /.foo.vm/ }
     end
 
     context shell('sudo -i -u nagios mco rpc rpcutil inventory -j </dev/null') do


### PR DESCRIPTION
This patch adds hiera configuration to configure 'rabbitmq.foo.vm' with
rabbitmq, so we have end-to-end testing there too.

To use:

```
RSPEC_SET=centos-64-x64-rabbitmq rake spec:system
```

This verifies that #86 is closed correctly by #89
