### PR TITLE
Fixed source plugin installation

### DIFF
--- a/manifests/common/config.pp
+++ b/manifests/common/config.pp
@@ -14,7 +14,7 @@ class mcollective::common::config {
   }
 
   file { "${mcollective::site_libdir}/mcollective":
-    require      => File["${mcollective::site_libdir}"],
+    require      => File[$mcollective::site_libdir],
     ensure       => directory,
     owner        => 'root',
     group        => 'root',


### PR DESCRIPTION
There was a missing subfolder with the name 'mcollective' in the $site_libdir, where the source plugin files should be placed.
