### PR TITLE
Use numeric group ID to allow portability to *BSD.

### DIFF
--- a/manifests/actionpolicy.pp
+++ b/manifests/actionpolicy.pp
@@ -5,7 +5,7 @@
 define mcollective::actionpolicy($default = 'deny') {
   datacat { "mcollective::actionpolicy ${name}":
     owner    => 'root',
-    group    => 'root',
+    group    => '0',
     mode     => '0400',
     path     => "/etc/mcollective/policies/${name}.policy",
     template => 'mcollective/actionpolicy.erb',

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -15,7 +15,7 @@ class mcollective::client::config {
   else {
     datacat { 'mcollective::client':
       owner    => 'root',
-      group    => 'root',
+      group    => '0',
       mode     => '0444',
       path     => $mcollective::client_config_file,
       template => 'mcollective/settings.cfg.erb',

--- a/manifests/common/config.pp
+++ b/manifests/common/config.pp
@@ -7,7 +7,7 @@ class mcollective::common::config {
   file { $mcollective::site_libdir:
     ensure       => directory,
     owner        => 'root',
-    group        => 'root',
+    group        => '0',
     recurse      => true,
     purge        => true,
     force        => true,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -6,7 +6,7 @@ class mcollective::server::config {
 
   datacat { 'mcollective::server':
     owner    => 'root',
-    group    => 'root',
+    group    => '0',
     mode     => '0400',
     path     => $mcollective::server_config_file,
     template => 'mcollective/settings.cfg.erb',
@@ -31,28 +31,28 @@ class mcollective::server::config {
   file { '/etc/mcollective/policies':
     ensure => 'directory',
     owner  => 'root',
-    group  => 'root',
+    group  => '0',
     mode   => '0700',
   }
 
   if $mcollective::middleware_ssl or $mcollective::securityprovider == 'ssl' {
     file { '/etc/mcollective/ca.pem':
       owner  => 'root',
-      group  => 'root',
+      group  => '0',
       mode   => '0444',
       source => $mcollective::ssl_ca_cert,
     }
 
     file { '/etc/mcollective/server_public.pem':
       owner  => 'root',
-      group  => 'root',
+      group  => '0',
       mode   => '0444',
       source => $mcollective::ssl_server_public,
     }
 
     file { '/etc/mcollective/server_private.pem':
       owner  => 'root',
-      group  => 'root',
+      group  => '0',
       mode   => '0400',
       source => $mcollective::ssl_server_private,
     }

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -8,7 +8,7 @@ class mcollective::server::config::factsource::yaml {
   # http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/FactsFacterYAML
   file { $mcollective::yaml_fact_path:
     owner   => 'root',
-    group   => 'root',
+    group   => '0',
     mode    => '0400',
     content => template('mcollective/facts.yaml.erb'),
   }

--- a/manifests/server/config/securityprovider/ssl.pp
+++ b/manifests/server/config/securityprovider/ssl.pp
@@ -7,7 +7,7 @@ class mcollective::server::config::securityprovider::ssl {
   file { '/etc/mcollective/clients':
     ensure  => 'directory',
     owner   => 'root',
-    group   => 'root',
+    group   => '0',
     purge   => true,
     recurse => true,
     mode    => '0400',


### PR DESCRIPTION
As mentioned in #101, the 'root' group doesn't exist everywhere. Using the group ID of '0' ensures that the 'wheel' group is being used on BSD and 'root' on Linux.
