### PR TITLE
make client-package name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ setting up rabbitmq middleware.
 Boolean: defaults to true.  Whether to install mcollective and mcollective-
 client packages when installing the server and client components.
 
+#### `client_package_name`
+
+String: defaults to 'mcollective-client'. Name of the package to be
+installed for the client.
+
 ##### `version`
 
 String: defaults to 'present'.  What version of packages to `ensure` when

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -5,7 +5,7 @@ class mcollective::client::install {
   }
 
   if $mcollective::manage_packages {
-    package { 'mcollective-client':
+    package { $mcollective::client_package_name:
       ensure => $mcollective::version,
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,7 @@ class mcollective (
   $client_config_file = '/etc/mcollective/client.cfg',
   $client_logger_type = 'console',
   $client_loglevel = 'warn',
+  $client_package_name = 'mcollective-client',
 
   # ssl certs
   $ssl_ca_cert = undef,

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -690,6 +690,11 @@ describe 'mcollective' do
         it { should contain_package('mcollective-client') }
       end
 
+      context '#client_package_name' do
+        let(:params) { { :client => true, :manage_packages => true, :client_package_name => 'mco-client' } }
+        it { should contain_package('mco-client') }
+      end
+
       context 'false' do
         let(:params) { { :client => true, :manage_packages => false } }
         it { should_not contain_package('mcollective-client') }


### PR DESCRIPTION
OpenBSD's mcollective package is not split, therefore there is only a single package that needs to be installed.
