### PR TITLE
Allow plugin version control

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -8,13 +8,13 @@ define mcollective::plugin(
   # parameters
   $client = $mcollective::client,
   $server = $mcollective::server,
-  $version = 'present',
+  $package_ensure = 'present',
 ) {
   if $package {
     # install from a package named "mcollective-${name}-${type}"
     $package_name = "mcollective-${name}-${type}"
     package { $package_name:
-      ensure => $version,
+      ensure => $package_ensure,
     }
 
     if $server {
@@ -25,7 +25,7 @@ define mcollective::plugin(
     # install the client package if we're installing on a $mcollective::client
     if $client and $has_client {
       package { "mcollective-${name}-client":
-        ensure => $version,
+        ensure => $package_ensure,
       }
     }
   }


### PR DESCRIPTION
MODULES-453: When a package plugin is specified, we should be able to set the value of ensure through a variable called version.
