### PR TITLE
Allow specifying pacakge version for ruby-stomp

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,12 @@ client packages when installing the server and client components.
 String: defaults to 'present'.  What version of packages to `ensure` when
 `mcollective::manage_packages` is true.
 
+##### `ruby_stomp_ensure`
+
+String: defaults to 'installed'.  What version of the ruby-stomp package to
+`ensure` when `mcollective::manage_packages` is true. Only relevant on the
+Debian OS family.
+
 ##### `main_collective`
 
 String: defaults to 'mcollective'.  The name of the main collective for this

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class mcollective (
   # installing packages
   $manage_packages = true,
   $version = 'present',
+  $ruby_stomp_ensure = 'installed',
 
   # core configuration
   $main_collective = 'mcollective',

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -13,7 +13,7 @@ class mcollective::server::install {
       # XXX the dependencies my test ubuntu 12.04 system seem to not correctly state
       # ruby-stomp as a dependency of mcollective, so hand specify
       package { 'ruby-stomp':
-        ensure => 'installed',
+        ensure => $mcollective::ruby_stomp_ensure,
         before => Package['mcollective'],
       }
     }

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -40,6 +40,23 @@ describe 'mcollective' do
       end
     end
 
+    describe '#ruby_stomp_ensure' do
+      let(:facts) { { :osfamily => 'Debian' } }
+      it 'should default to installed' do
+        should contain_package('ruby-stomp').with_ensure('installed')
+      end
+      
+      context 'latest' do
+        let(:params) { { :ruby_stomp_ensure => 'latest' } }
+        it { should contain_package('ruby-stomp').with_ensure('latest') }
+      end
+
+      context '1.2.10-1puppetlabs1' do
+        let(:params) { { :ruby_stomp_ensure => '1.2.10-1puppetlabs1' } }
+        it { should contain_package('ruby-stomp').with_ensure('1.2.10-1puppetlabs1') }
+      end
+    end
+
     describe '#main_collective' do
       context 'default' do
         it { should contain_mcollective__common__setting('main_collective').with_value('mcollective') }


### PR DESCRIPTION
Add a new parameter $mcollective::ruby_stomp_version which defaults to
'installed'. Since this module manages the ruby-stomp package resource
it should also be possible to specify which package version to ensure.

Contains updated documentation and simple spec tests. Fixes MODULES-459.
