### PR TITLE
Exclude `path` fact from facts.yaml

### DIFF
--- a/templates/facts.yaml.erb
+++ b/templates/facts.yaml.erb
@@ -2,7 +2,7 @@
     # remove dynamic facts and non-string values
     # last_run fact comes from the puppi module
     obj = scope.compiler.topscope.to_hash.reject { |k,v|
-        (k.to_s =~ /^(uptime.*|rubysitedir|_timestamp|memoryfree.*|swapfree.*|last_run)$/i) || (v.class != ::String)
+        (k.to_s =~ /^(uptime.*|rubysitedir|_timestamp|memoryfree.*|swapfree.*|last_run|path)$/i) || (v.class != ::String)
     }
 
     arr = obj.sort


### PR DESCRIPTION
The `path` fact is a somewhat dynamic, having different values depending
on who initiates a puppet agent run (a user or Cron/daemon). This leads
to Mcollective restarting when the fact value changes which is
unnecessary and noisy. Preventing `path` from ending up in facts.yaml
quiets things down. Fixes #129.
