### PR TITLE
Allow listing facts to exclude from facts.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,15 @@ server.
 String: defaults to '/etc/mcollective/facts.yaml'.  Name of the file the
 'yaml' factsource plugin should load facts from.
 
+##### `excluded_facts`
+Array: defaults to []. List of facts to exclude from facts.yaml when
+`factsource` is 'yaml'. This is useful for preventing dynamic facts (that
+change on each Puppet run) from ending up in facts.yaml, which would trigger
+restarts of Mcollective. A default list of facts to ignore is managed
+internally: `uptime.*`, `rubysitedir`, `_timestamp`, `memoryfree.*`,
+`swapfree.*` and `last_run`. Note that the fact names can be Ruby regular
+expressions.
+
 ##### `classesfile`
 
 String: defaults to '/var/lib/puppet/state/classes.txt'.  Name of the file the

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class mcollective (
   $psk = 'changemeplease',
   $factsource = 'yaml',
   $yaml_fact_path = '/etc/mcollective/facts.yaml',
+  $excluded_facts = [],
   $classesfile = '/var/lib/puppet/state/classes.txt',
   $rpcauthprovider = 'action_policy',
   $rpcauditprovider = 'logfile',

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -4,6 +4,8 @@ class mcollective::server::config::factsource::yaml {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
+  $excluded_facts = $mcollective::excluded_facts
+
   # This pattern originally from
   # http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/FactsFacterYAML
   file { $mcollective::yaml_fact_path:

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -164,6 +164,35 @@ describe 'mcollective' do
           end
         end
 
+        describe '#excluded_facts' do
+          context 'dynamic fact removal with user-supplied facts' do
+            let(:params) { { :excluded_facts => [ 'path', 'last_root_login' ] } }
+            let(:facts) do
+              {
+                :last_run        => 'Wed Oct 16 10:16:10 MST 2013',
+                :memoryfree      => '5.78 GB',
+                :memoryfree_mb   => '5915.74',
+                :rubysitedir     => '/usr/lib/ruby/site_ruby/1.8',
+                :swapfree        => '2.00 GB',
+                :swapfree_mb     => '2047.99',
+                :uptime          => '16:20 hours',
+                :uptime_days     => '0',
+                :uptime_hours    => '16',
+                :uptime_seconds  => '58838',
+                :path            => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/X11R6/bin',
+                :last_root_login => 'Fri Mar 21 17:11:03 CET 2014',
+              }
+            end
+
+            it { should contain_file('/etc/mcollective/facts.yaml') }
+            it do
+              facts.keys.each do |k|
+                should_not contain_file('/etc/mcollective/facts.yaml').with_content(/^#{k.to_s}.*/m)
+              end
+            end
+          end
+        end
+
         describe '#yaml_fact_path' do
           it 'should default to /etc/mcollective/facts.yaml' do
             should contain_mcollective__server__setting('plugin.yaml').with_value('/etc/mcollective/facts.yaml')

--- a/templates/facts.yaml.erb
+++ b/templates/facts.yaml.erb
@@ -1,8 +1,17 @@
 <%=
     # remove dynamic facts and non-string values
     # last_run fact comes from the puppi module
+
+    default_excluded_facts = [
+      'uptime.*', 'rubysitedir', '_timestamp', 'memoryfree.*', 'swapfree.*',
+      'last_run', 'clientnoop'
+    ]
+    all_excluded_facts = default_excluded_facts + @excluded_facts
+
+    excluded_facts_re = Regexp.new( "^(" + all_excluded_facts.join("|") + ")$", true)
+
     obj = scope.compiler.topscope.to_hash.reject { |k,v|
-        (k.to_s =~ /^(uptime.*|rubysitedir|_timestamp|memoryfree.*|swapfree.*|last_run|clientnoop)$/i) || (v.class != ::String)
+      (k.to_s =~ excluded_facts_re) || (v.class != ::String)
     }
 
     arr = obj.sort


### PR DESCRIPTION
Add a new parameter `$mcollective::excluded_facts`, defaulting to `[]`.
The facts specified therein are added to the default list of facts to
exclude from the generated facts.yaml.

Contains updated documentation and spec tests.
