### PR TITLE
add clientnoop to the list of dynamic facts that are filtered out

### DIFF
--- a/templates/facts.yaml.erb
+++ b/templates/facts.yaml.erb
@@ -2,7 +2,7 @@
     # remove dynamic facts and non-string values
     # last_run fact comes from the puppi module
     obj = scope.compiler.topscope.to_hash.reject { |k,v|
-        (k.to_s =~ /^(uptime.*|rubysitedir|_timestamp|memoryfree.*|swapfree.*|last_run)$/i) || (v.class != ::String)
+        (k.to_s =~ /^(uptime.*|rubysitedir|_timestamp|memoryfree.*|swapfree.*|last_run|clientnoop)$/i) || (v.class != ::String)
     }
 
     arr = obj.sort


### PR DESCRIPTION
So running puppet --noop doesn't show differences in the facts.yaml file
