### PR TITLE
use provided certificate files in client config if using activemq ssl

### DIFF
--- a/manifests/client/config/connector/activemq.pp
+++ b/manifests/client/config/connector/activemq.pp
@@ -1,0 +1,19 @@
+# private class
+class mcollective::client::config::connector::activemq {
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
+  # handle the case that activemq connection is ssl encrypted and psk secured
+  if $mcollective::middleware_ssl and $mcollective::securityprovider == "psk" {
+    
+    mcollective::client::setting { "plugin.activemq.pool.1.ssl.cert":
+      value => '/etc/mcollective/server_public.pem',
+    }
+    
+    mcollective::client::setting { "plugin.activemq.pool.1.ssl.key":
+      value => '/etc/mcollective/server_private.pem',
+    }
+    
+  }
+}


### PR DESCRIPTION
Only used in conjunction with $securityprovider => psk . Uses $ssl_.+ certificates from ::mcollective call. This provides an mcollective out-of-the-box on a node that provides all three components (activemq, mcollective-server, mcollective-client) like this:

class { '::mcollective':
      middleware_hosts   => [ $::fqdn ],
      middleware         => true,
      client             => true,
      middleware_ssl     => true,
      securityprovider   => 'psk',
      psk                => 'changemeplease',
    ssl_client_certs   => 'puppet:///modules/site_mcollective/client_certs',
    ssl_ca_cert        => 'puppet:///modules/site_mcollective/certs/ca.pem',
    ssl_server_public  => 'puppet:///modules/site_mcollective/certs/server.pem',
    ssl_server_private => 'puppet:///modules/site_mcollective/private_keys/server.pem',
}
