### PR TITLE
Added identity parameter so that hosts would export fqdn as identity regardless of the hostname configuartion.

### DIFF
--- a/manifests/common/config.pp
+++ b/manifests/common/config.pp
@@ -54,6 +54,10 @@ class mcollective::common::config {
     value => $mcollective::main_collective,
   }
 
+  mcollective::common::setting { 'identity':
+    value => $mcollective::identity,
+  }
+
   mcollective::soft_include { [
     "::mcollective::common::config::connector::${mcollective::connector}",
     "::mcollective::common::config::securityprovider::${mcollective::securityprovider}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@ class mcollective (
   $registration = undef,
   $core_libdir = $mcollective::defaults::core_libdir,
   $site_libdir = $mcollective::defaults::site_libdir,
+  $identity = $fqdn,
 
   # networking
   $middleware_hosts = [],


### PR DESCRIPTION
While using Mcollective with Foreman, if hosts are not exporting fqdn to mcollective, 'puppet run' from foreman would not work, as foreman-proxy uses fqdn for 'mco puppet runonce <hostname>' command . 

Socket.gethostname is used for finding identity by default and could give just hostname in configurations like following.. 

```
[root@centos ~]# cat /etc/sysconfig/network
NETWORKING=yes
HOSTNAME=centos
DOMAINNAME=ppp.com
```

```
1.9.3-p484 :002 > Socket.gethostname
 => "centos" 
```

Facter is more reliable..

```
# facter fqdn
centos.ppp.com
```
