### PR TITLE
Add show_fact_diff parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,10 @@ internally: `uptime.*`, `rubysitedir`, `_timestamp`, `memoryfree.*`,
 `swapfree.*` and `last_run`. Note that the fact names can be Ruby regular
 expressions.
 
+##### `show_fact_diff`
+Boolean: defaults to undef. Whether to generate a diff for the generated
+facts.yaml file. Set this to false if your facts contain private information.
+
 ##### `classesfile`
 
 String: defaults to '/var/lib/puppet/state/classes.txt'.  Name of the file the

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class mcollective (
   $factsource = 'yaml',
   $yaml_fact_path = '/etc/mcollective/facts.yaml',
   $excluded_facts = [],
+  $show_fact_diff = undef,
   $classesfile = '/var/lib/puppet/state/classes.txt',
   $rpcauthprovider = 'action_policy',
   $rpcauditprovider = 'logfile',

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -9,10 +9,11 @@ class mcollective::server::config::factsource::yaml {
   # This pattern originally from
   # http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/FactsFacterYAML
   file { $mcollective::yaml_fact_path:
-    owner   => 'root',
-    group   => '0',
-    mode    => '0400',
-    content => template('mcollective/facts.yaml.erb'),
+    owner     => 'root',
+    group     => '0',
+    mode      => '0400',
+    content   => template('mcollective/facts.yaml.erb'),
+    show_diff => $mcollective::show_fact_diff,
   }
 
   mcollective::server::setting { 'factsource':


### PR DESCRIPTION
Introduce a new show_fact_diff parameter to control whether a diff
for the generated facts.yaml should be generated.
