### PR TITLE
Fix yaml_fact_path parameter bug

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -4,11 +4,11 @@ class mcollective::server::config::factsource::yaml {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  $excluded_facts = $mcollective::excluded_facts
-  $mco_etc = $mcollective::confdir
+  $excluded_facts      = $mcollective::excluded_facts
+  $yaml_fact_path_real = $mcollective::yaml_fact_path_real
 
   # Template uses:
-  #   - $mco_etc
+  #   - $yaml_fact_path_real
   file { "${mcollective::core_libdir}/refresh-mcollective-metadata":
     owner   => '0',
     group   => '0',
@@ -25,7 +25,7 @@ class mcollective::server::config::factsource::yaml {
   exec { 'create-mcollective-metadata':
     path    => "/opt/puppet/bin:${::path}",
     command => "${mcollective::core_libdir}/refresh-mcollective-metadata",
-    creates => "${mco_etc}/facts.yaml",
+    creates => $yaml_fact_path_real,
     require => File["${mcollective::core_libdir}/refresh-mcollective-metadata"],
   }
 
@@ -34,6 +34,6 @@ class mcollective::server::config::factsource::yaml {
   }
 
   mcollective::server::setting { 'plugin.yaml':
-    value => $mcollective::yaml_fact_path_real,
+    value => $yaml_fact_path_real,
   }
 }

--- a/templates/refresh-mcollective-metadata.erb
+++ b/templates/refresh-mcollective-metadata.erb
@@ -7,8 +7,8 @@ Facter::Application.load_puppet
 
 facts = YAML.dump(Facter.to_hash)
 
-File.open('<%= @mco_etc -%>/facts.yaml.new', 'w') do |f|
+File.open('<%= @yaml_fact_path_real -%>.new', 'w') do |f|
   f.puts facts
 end
 
-File.rename('<%= @mco_etc -%>/facts.yaml.new', '<%= @mco_etc -%>/facts.yaml')
+File.rename('<%= @yaml_fact_path_real -%>.new', '<%= @yaml_fact_path_real -%>')


### PR DESCRIPTION
Previously the yaml_fact_path parameter was inconsistently honored, and
sometimes the hard-coded default /etc/mcollective/facts.yaml was used
instead. This commit updates the template and the manifest to honor it
everywhere that is relevant.

This needs to be tested before merge.
