### PR TITLE
Release 2.0.0-rc0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,9 @@
 ---
 fixtures:
   repositories:
+    concat:
+      repo: 'https://github.com/puppetlabs/puppetlabs-concat.git'
+      ref: '1.0.4'
     datacat:
       repo: 'https://github.com/richardc/puppet-datacat.git'
       ref: '0.5.0'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,20 @@
+2014-07-23 Release 2.0.0-rc0
+Summary:
+
+This is a fairly large rewrite of many parts of the mcollective module to
+remove the management of activemq and rabbitmq (middleware) since this task
+should be delegated to activemq/rabbitmq modules. See the examples/ directory
+for example profiles to replicate previous configuration.
+
+Backwards-incompatible Features:
+- This section should be filled out before final release
+
+Features:
+- This section should be filled out before final release
+
+Bugfixes:
+- This section should be filled out before final release
+
 2014-07-15 Release 1.1.6
 
 Summary:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-mcollective",
-  "version": "1.1.6",
+  "version": "2.0.0-rc0",
   "author": "puppetlabs",
   "summary": "MCollective Puppet Module",
   "license": "Apache License, Version 2.0",
@@ -10,11 +10,21 @@
   "types": [
   
   ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.4.0"
+    }
+  ],
   "description": "MCollective Puppet Module",
   "dependencies": [
     {
       "name": "richardc/datacat",
       "version_requirement": "0.5.x"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": "1.x"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Summary:

This is a fairly large rewrite of many parts of the mcollective module
to remove the management of activemq and rabbitmq (middleware) since
this task should be delegated to activemq/rabbitmq modules. See the
examples/ directory for example profiles to replicate previous
configuration.

Backwards-incompatible Features:
- This section should be filled out before final release

Features:
- This section should be filled out before final release

Bugfixes:
- This section should be filled out before final release
