### PR TITLE
(MODULES-773) Use string for host_iteration titles in future parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,13 @@
-branches:
-  only:
-    - master
+---
 language: ruby
 bundler_args: --without development
-script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
-after_success:
-  - git clone -q git://github.com/puppetlabs/ghpublisher.git .forge-release
-  - .forge-release/publish
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-env:
-  matrix:
-    - PUPPET_GEM_VERSION="~> 3.4.0"
-    - PUPPET_GEM_VERSION="~> 3.5.0"
-    - PUPPET_GEM_VERSION="~> 3.6.0"
-  global:
-    - PUBLISHER_LOGIN=puppetlabs
-    - secure: iI91FnYPqlR7+KQBga6ujKB/3N+Wv91mvGhSdAkLl+HsncKLglH+epjXMJ4DLrv08W9msQ+u/ZA6nvAKv9sQTPb/RKx67mC56CHEHguKwCBPsVdJRVjMBseMTl+9INiG58s9uJKA3LRfGd760+WMYJUwDyh+lWTrTOmwNm4WfKI=
+script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
+matrix:
+  fast_finish: true
+  include:
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.0"
 notifications:
   email: false

--- a/lib/puppet/parser/functions/mco_array_to_string.rb
+++ b/lib/puppet/parser/functions/mco_array_to_string.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# vim: set sw=2 sts=2 et tw=80 :
+Puppet::Parser::Functions.newfunction(:mco_array_to_string, :type => :rvalue) do |args|
+  if ! args[0].is_a? Array
+    raise ArgumentError, "Expected an array, but got a #{args[0].class}"
+  end
+
+  args[0].collect do |elem|
+    elem.to_s
+  end
+end

--- a/manifests/common/config/connector/activemq.pp
+++ b/manifests/common/config/connector/activemq.pp
@@ -21,6 +21,6 @@ class mcollective::common::config::connector::activemq {
     value => $pool_size,
   }
 
-  $indexes = range('1', $pool_size)
+  $indexes = mco_array_to_string(range('1', $pool_size))
   mcollective::common::config::connector::activemq::hosts_iteration { $indexes: }
 }


### PR DESCRIPTION
In the future parser, integers are not allowed as titles. The range()
function in stdlib explicitly returns integers when the arguments are
digits (even String digits), so they must be cast from integers to
strings to use as titles. String + Integer math is still valid in the
future parser, so this should still work as intended.

It already has unit tests showing this behavior with the standard
parser. rspec-puppet does not yet work with the future parser due to
its use of `import`.
