### PR TITLE
(MODULES-1420) Add yaml_fact_cron_path_env and facts_package_ensure parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,16 @@ String: defaults to 'puppet:///modules/mcollective/empty'.  A file source that
 contains a directory of user certificates which are used by the ssl security
 provider in authenticating user requests.
 
+##### `yaml_fact_cron_path_env`
+
+String: defaults to '/opt/puppet/bin:${::path}'.  The value for PATH used by cron 
+and exec resources that populate the yaml factsource file.
+
+##### `facts_package_ensure`
+
+String: defaults to 'present'.  Sets the ensure property for the
+mcollective-facter-facts package.
+
 ### `mcollective::user` defined type
 
 `mcollective::user` installs a client configuration and any needed client

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -18,4 +18,7 @@ class mcollective::defaults {
     'Debian' => '/usr/local/share/mcollective',
     default  => '/usr/local/libexec/mcollective',
   }
+
+  # environment passed to factsource yaml cron resource
+  $yaml_fact_cron_path_env = "/opt/puppet/bin:${::path}"
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,10 @@ class mcollective (
   $ssl_server_private   = undef,
   $ssl_client_certs     = 'puppet:///modules/mcollective/empty',
   $ssl_client_certs_dir = undef, # default dependent on $confdir
+
+  # factsource options
+  $yaml_fact_cron_path_env = $mcollective::defaults::yaml_fact_cron_path_env,
+  $facts_package_ensure    = 'present',
 ) inherits mcollective::defaults {
 
   # Because the correct default value for several parameters is based on another

--- a/manifests/server/config/factsource/facter.pp
+++ b/manifests/server/config/factsource/facter.pp
@@ -5,9 +5,10 @@ class mcollective::server::config::factsource::facter {
   }
 
   mcollective::plugin { 'facter':
-    type       => 'facts',
-    package    => true,
-    has_client => false,
+    type           => 'facts',
+    package        => true,
+    has_client     => false,
+    package_ensure => $mcollective::facts_package_ensure,
   }
 
   mcollective::server::setting { 'factsource':

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -17,13 +17,13 @@ class mcollective::server::config::factsource::yaml {
     before  => Cron['refresh-mcollective-metadata'],
   }
   cron { 'refresh-mcollective-metadata':
-    environment => "PATH=/opt/puppet/bin:${::path}",
+    environment => "PATH=${mcollective::yaml_fact_cron_path_env}",
     command     => "${mcollective::core_libdir}/refresh-mcollective-metadata",
     user        => 'root',
     minute      => [ '0', '15', '30', '45' ],
   }
   exec { 'create-mcollective-metadata':
-    path    => "/opt/puppet/bin:${::path}",
+    path    => $mcollective::yaml_fact_cron_path_env,
     command => "${mcollective::core_libdir}/refresh-mcollective-metadata",
     creates => $yaml_fact_path_real,
     require => File["${mcollective::core_libdir}/refresh-mcollective-metadata"],


### PR DESCRIPTION
The yaml_fact_cron_path_env parameter can be used to override the value of PATH for the cron
and exec resources managing the yaml factsource.

The facts_package_ensure parameter can override the package_ensure value used when
defining Mcollective::Plugin[facter]