### PR TITLE
We need to provide a seperate shared public key and certificate for all servers

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,8 @@ class mcollective (
   $ssl_server_private   = undef,
   $ssl_client_certs     = 'puppet:///modules/mcollective/empty',
   $ssl_client_certs_dir = undef, # default dependent on $confdir
+  $ssl_shared_server_public = undef,
+  $ssl_shared_server_private = undef,
 ) inherits mcollective::defaults {
 
   # Because the correct default value for several parameters is based on another
@@ -72,6 +74,16 @@ class mcollective (
   $server_config_file_real = pick($server_config_file, "${confdir}/server.cfg")
   $client_config_file_real = pick($client_config_file, "${confdir}/client.cfg")
   $ssl_client_certs_dir_real = pick($ssl_client_certs_dir, "${confdir}/clients")
+  if ($ssl_shared_server_public == undef) {
+    $ssl_shared_server_public_real = $ssl_server_public
+  } else {
+    $ssl_shared_server_public_real = $ssl_shared_server_public
+  }
+  if ($ssl_shared_server_private == undef) {
+    $ssl_shared_server_private_real = $ssl_server_private
+  } else {
+    $ssl_shared_server_private_real = $ssl_shared_server_private
+  }
 
   if $client or $server {
     contain mcollective::common

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -56,6 +56,20 @@ class mcollective::server::config {
       mode   => '0400',
       source => $mcollective::ssl_server_private,
     }
+
+    file { "${mcollective::confdir}/shared_server_public.pem":
+      owner  => 'root',
+      group  => '0',
+      mode   => '0444',
+      source => $mcollective::ssl_shared_server_public_real,
+    }
+
+    file { "${mcollective::confdir}/shared_server_private.pem":
+      owner  => 'root',
+      group  => '0',
+      mode   => '0400',
+      source => $mcollective::ssl_shared_server_private_real,
+    }
   }
 
   mcollective::soft_include { [

--- a/manifests/server/config/securityprovider/ssl.pp
+++ b/manifests/server/config/securityprovider/ssl.pp
@@ -19,10 +19,10 @@ class mcollective::server::config::securityprovider::ssl {
   }
 
   mcollective::server::setting { 'plugin.ssl_server_public':
-    value => "${mcollective::confdir}/server_public.pem",
+    value => "${mcollective::confdir}/shared_server_public.pem",
   }
 
   mcollective::server::setting { 'plugin.ssl_server_private':
-    value => "${mcollective::confdir}/server_private.pem",
+    value => "${mcollective::confdir}/shared_server_private.pem",
   }
 }

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -284,6 +284,20 @@ describe 'mcollective' do
               end
             end
 
+            describe '#ssl_shared_server_public' do
+              context 'set' do
+                let(:params) { common_params.merge({ :ssl_server_public => 'puppet:///modules/foo/server_public.pem' }) }
+                it { should contain_file('/etc/mcollective/shared_server_public.pem').with_source('puppet:///modules/foo/server_public.pem') }
+              end
+            end
+
+            describe '#ssl_shared_server_private' do
+              context 'set' do
+                let(:params) { common_params.merge({ :ssl_server_private => 'puppet:///modules/foo/server_private.pem' }) }
+                it { should contain_file('/etc/mcollective/shared_server_private.pem').with_source('puppet:///modules/foo/server_private.pem') }
+              end
+            end
+
             describe '#ssl_server_fallback' do
               context 'set' do
                 let(:params) { common_params.merge({ :middleware_ssl_fallback => true }) }
@@ -353,8 +367,8 @@ describe 'mcollective' do
 
       context 'ssl' do
         let(:params) { { :server => true, :securityprovider => 'ssl' } }
-        it { should contain_mcollective__server__setting('plugin.ssl_server_public').with_value('/etc/mcollective/server_public.pem') }
-        it { should contain_file('/etc/mcollective/server_public.pem') }
+        it { should contain_mcollective__server__setting('plugin.ssl_server_public').with_value('/etc/mcollective/shared_server_public.pem') }
+        it { should contain_file('/etc/mcollective/shared_server_public.pem') }
 
         describe '#ssl_client_certs' do
           it { should contain_file('/etc/mcollective/clients') }
@@ -576,8 +590,8 @@ describe 'mcollective' do
 
       context 'ssl' do
         let(:params) { { :server => true, :securityprovider => 'ssl' } }
-        it { should contain_mcollective__server__setting('plugin.ssl_server_public').with_value('/etc/mcollective/server_public.pem') }
-        it { should contain_file('/etc/mcollective/server_public.pem') }
+        it { should contain_mcollective__server__setting('plugin.ssl_server_public').with_value('/etc/mcollective/shared_server_public.pem') }
+        it { should contain_file('/etc/mcollective/shared_server_public.pem') }
       end
 
       context 'psk' do


### PR DESCRIPTION
Acording to the "Standard MCollective Deployment Guide" we need to provide a shared public and private keys for all servers. So we must be able to provide these in the mcollective class for the server.