### PR TITLE
Space out refresh-mcollective-metadata cron task

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -7,6 +7,9 @@ class mcollective::server::config::factsource::yaml {
   $excluded_facts      = $mcollective::excluded_facts
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
 
+  $cron_minute_value   = fqdn_rand(60, ${::macaddress})
+  $cron_hour_value     = '0-23/2'
+
   # Template uses:
   #   - $yaml_fact_path_real
   file { "${mcollective::core_libdir}/refresh-mcollective-metadata":
@@ -20,7 +23,8 @@ class mcollective::server::config::factsource::yaml {
     environment => "PATH=/opt/puppet/bin:${::path}",
     command     => "${mcollective::core_libdir}/refresh-mcollective-metadata",
     user        => 'root',
-    minute      => [ '0', '15', '30', '45' ],
+    minute      => $cron_minute_value,
+    hour        => $cron_hour_value,
   }
   exec { 'create-mcollective-metadata':
     path    => "/opt/puppet/bin:${::path}",

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -7,9 +7,6 @@ class mcollective::server::config::factsource::yaml {
   $excluded_facts      = $mcollective::excluded_facts
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
 
-  $cron_minute_value   = fqdn_rand(60, ${::macaddress})
-  $cron_hour_value     = '0-23/2'
-
   # Template uses:
   #   - $yaml_fact_path_real
   file { "${mcollective::core_libdir}/refresh-mcollective-metadata":
@@ -23,8 +20,7 @@ class mcollective::server::config::factsource::yaml {
     environment => "PATH=/opt/puppet/bin:${::path}",
     command     => "${mcollective::core_libdir}/refresh-mcollective-metadata",
     user        => 'root',
-    minute      => $cron_minute_value,
-    hour        => $cron_hour_value,
+    minute      => [ '0', '15', '30', '45' ],
   }
   exec { 'create-mcollective-metadata':
     path    => "/opt/puppet/bin:${::path}",

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -7,8 +7,8 @@ class mcollective::server::config::factsource::yaml {
   $excluded_facts      = $mcollective::excluded_facts
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
 
-  $cron_minute_offset  = fqdn_rand(15, ${::macaddress})
-  $cron_minutes = [ $cron_minute_offset, $cron_minute_offset + 15, 
+  $cron_minute_offset  = fqdn_rand(15, $::macaddress)
+  $cron_minutes        = [ $cron_minute_offset, $cron_minute_offset + 15, 
     $cron_minute_offset + 30, $cron_minute_offset + 45 ]
 
   # Template uses:

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -7,6 +7,10 @@ class mcollective::server::config::factsource::yaml {
   $excluded_facts      = $mcollective::excluded_facts
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
 
+  $cron_minute_offset  = fqdn_rand(15, ${::macaddress})
+  $cron_minutes = [ $cron_minute_offset, $cron_minute_offset + 15, 
+    $cron_minute_offset + 30, $cron_minute_offset + 45 ]
+
   # Template uses:
   #   - $yaml_fact_path_real
   file { "${mcollective::core_libdir}/refresh-mcollective-metadata":
@@ -20,7 +24,7 @@ class mcollective::server::config::factsource::yaml {
     environment => "PATH=/opt/puppet/bin:${::path}",
     command     => "${mcollective::core_libdir}/refresh-mcollective-metadata",
     user        => 'root',
-    minute      => [ '0', '15', '30', '45' ],
+    minute      => $cron_minutes,
   }
   exec { 'create-mcollective-metadata':
     path    => "/opt/puppet/bin:${::path}",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-mcollective",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "puppetcommunity",
   "summary": "Installs, configures, and manages MCollective agents, clients, and middleware of an MCollective cluster.",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-mcollective",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": "puppetcommunity",
   "summary": "Installs, configures, and manages MCollective agents, clients, and middleware of an MCollective cluster.",
   "license": "Apache-2.0",


### PR DESCRIPTION
refresh-mcollective-metadata is being run at four fixed moments within each hour. In certain  configurations with hundreds of virtual machines, all managed by puppet, this simultaneous start of  refresh-mcollective-metadata is causing a large CPU steal (ready) time, from seconds to minutes, during which the hypervisors need to deal with the large sudden demand of CPU cycles coming from virtual machines that are agressively competing for CPU resources. To prevent these outages, the refresh-mcollective-metadata cron job should be spaced out over various moments in time, and started less often.

Hypervisor with simultaneous starts of refresh-mcollective-metadata via cron:
![cpu-ready-without-cron-patch](https://cloud.githubusercontent.com/assets/4489529/6816766/bcb4e242-d297-11e4-9148-264d1253f12a.jpg)

Hypervisor with spaced out start of the refresh-mcollective-metadata cron jobs (rolling out patch on  virtual machines started at 15:20)
![cpu-ready-with-cron-patch](https://cloud.githubusercontent.com/assets/4489529/6816775/c5f1e972-d297-11e4-8c48-ce059a15eaac.jpg)

