### PR TITLE
Add support for OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,18 @@ client packages when installing the server and client components.
 String: defaults to 'present'.  What version of packages to `ensure` when
 `mcollective::manage_packages` is true.
 
+##### `client_package`
+
+String: defaults to 'mcollective-client'. The name of the package to install for
+the client part. In the case that there is only one package package handling both,
+client and server, give the same name for 'client_package' and 'server_package'.
+
+##### `server_package`
+
+String: defaults to 'mcollective'. The name of the package to install for
+the server. In the case that there is only one package package handling both,
+client and server, give the same name for 'client_package' and 'server_package'.
+
 ##### `ruby_stomp_ensure`
 
 String: defaults to 'installed'.  What version of the ruby-stomp package to
@@ -240,6 +252,13 @@ server.
 
 String: defaults to '/etc/mcollective/facts.yaml'.  Name of the file the
 'yaml' factsource plugin should load facts from.
+
+##### `ruby_interpreter`
+
+String: defaults to '/usr/bin/env ruby' for non PE installations, and to
+'/opt/puppet/bin/ruby' for PE installations. With `factsource` 'yaml', a ruby
+script is installed as cron job, which needs to find the ruby interpreter.
+This parameter allows overriding the default interpreter.
 
 ##### `classesfile`
 

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -5,8 +5,11 @@ class mcollective::client::install {
   }
 
   if $mcollective::manage_packages {
-    package { $mcollective::client_package:
-      ensure => $mcollective::version,
+    # prevent conflict where client package name == server package name
+    if $mcollective::client_package != $mcollective::server_package {
+      package { $mcollective::client_package:
+        ensure => $mcollective::version,
+      }
     }
   }
 }

--- a/manifests/common/config/connector/activemq/hosts_iteration.pp
+++ b/manifests/common/config/connector/activemq/hosts_iteration.pp
@@ -6,7 +6,9 @@ define mcollective::common::config::connector::activemq::hosts_iteration {
     value => $middleware_hosts_array[$name - 1],
   }
 
-  $port = $mcollective::middleware_ssl ? {
+  $middleware_ssl = str2bool($mcollective::middleware_ssl)
+
+  $port = $middleware_ssl ? {
     true    => $mcollective::middleware_ssl_port,
     default => $mcollective::middleware_port,
   }
@@ -28,7 +30,7 @@ define mcollective::common::config::connector::activemq::hosts_iteration {
     value => $mcollective::middleware_password,
   }
 
-  if $mcollective::middleware_ssl {
+  if $middleware_ssl {
     mcollective::common::setting { "plugin.activemq.pool.${name}.ssl":
       value => 1,
     }

--- a/manifests/common/config/connector/rabbitmq/hosts_iteration.pp
+++ b/manifests/common/config/connector/rabbitmq/hosts_iteration.pp
@@ -5,7 +5,9 @@ define mcollective::common::config::connector::rabbitmq::hosts_iteration {
     value => $mcollective::middleware_hosts[$name - 1], # puppet array 0-based
   }
 
-  $port = $mcollective::middleware_ssl ? {
+  $middleware_ssl = str2bool($mcollective::middleware_ssl)
+
+  $port = $middleware_ssl ? {
     true    => $mcollective::middleware_ssl_port,
     default => $mcollective::middleware_port,
   }
@@ -27,7 +29,7 @@ define mcollective::common::config::connector::rabbitmq::hosts_iteration {
     value => $mcollective::middleware_password,
   }
 
-  if $mcollective::middleware_ssl {
+  if $middleware_ssl {
     mcollective::common::setting { "plugin.rabbitmq.pool.${name}.ssl":
       value => 1,
     }

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -8,16 +8,18 @@ class mcollective::defaults {
   if versioncmp($::puppetversion, '4') < 0 {
     $confdir = '/etc/mcollective'
     $_core_libdir = $::osfamily ? {
-      'Debian' => '/usr/share/mcollective/plugins',
-      default  => '/usr/libexec/mcollective',
+      'Debian'  => '/usr/share/mcollective/plugins',
+      'OpenBSD' => '/usr/local/libexec/mcollective',
+      default   => '/usr/libexec/mcollective',
     }
     # Where this module will sync file-managed plugins to.
     # These paths may need revisiting by someone who understands FHS and
     # distribution standards for site-specific application-specific
     # library paths.
     $site_libdir = $::osfamily ? {
-      'Debian' => '/usr/local/share/mcollective',
-      default  => '/usr/local/libexec/mcollective',
+      'Debian'  => '/usr/local/share/mcollective',
+      'OpenBSD' => regsubst($::rubyversion, '^(\d+)\.(\d+)\.(\d+)$', '/usr/local/lib/ruby/vendor_ruby/\1.\2/mcollective'),
+      default   => '/usr/local/libexec/mcollective',
     }
   } else {
     $confdir     = '/etc/puppetlabs/mcollective'
@@ -40,6 +42,19 @@ class mcollective::defaults {
     $server_daemonize = false # See https://tickets.puppetlabs.com/browse/MCO-167
   } else {
     $server_daemonize = true
+  }
+
+  if defined('$is_pe') and str2bool($::is_pe) {
+    $ruby_interpreter = '/opt/puppet/bin/ruby'
+  } else {
+    case $::operatingsystem {
+      'OpenBSD': {
+        $ruby_interpreter = regsubst($::rubyversion, '^(\d+)\.(\d+)\.(\d+)$', '/usr/local/bin/ruby\1\2')
+      }
+      default: {
+        $ruby_interpreter = '/usr/bin/env ruby'
+      }
+    }
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,7 @@ class mcollective (
   $service_name       = 'mcollective',
   $server_package     = 'mcollective',
   $ruby_stomp_package = 'ruby-stomp',
+  $ruby_interpreter   = $mcollective::defaults::ruby_interpreter,
 
   # client-specific
   $client_config_file  = undef, # default dependent on $confdir

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -7,11 +7,7 @@ class mcollective::server::config::factsource::yaml (
   }
 
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
-  if defined('$is_pe') and str2bool($::is_pe) {
-    $ruby_shebang_path = '/opt/puppet/bin/ruby'
-  } else {
-    $ruby_shebang_path = '/usr/bin/env ruby'
-  }
+  $ruby_shebang_path   = $mcollective::ruby_interpreter
   $yaml_fact_cron      = $mcollective::yaml_fact_cron
 
   if $mcollective::fact_cron_splay {
@@ -56,7 +52,7 @@ class mcollective::server::config::factsource::yaml (
       # PATH as environment is global. Therefore, prefix the command itself in
       # the cron job with the value of the PATH environment variable to use.
       cron { 'refresh-mcollective-metadata':
-        command => "bash -c 'export PATH=${path}; ${mcollective::site_libdir}/refresh-mcollective-metadata >/dev/null 2>&1'",
+        command => "/bin/sh -c 'export PATH=${path}; ${mcollective::site_libdir}/refresh-mcollective-metadata >/dev/null 2>&1'",
         user    => 'root',
         minute  => $cron_minutes,
         require => File["${mcollective::site_libdir}/refresh-mcollective-metadata"],

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -294,7 +294,6 @@ describe 'mcollective' do
         end
 
         describe '#fact_cron_splay' do
-
           let(:facts) do
             {
               :puppetversion => Puppet.version,
@@ -445,6 +444,15 @@ describe 'mcollective' do
             it { should_not contain_file("#{mcollective_config_path}/ssl/middleware_ca.pem") }
             it { should_not contain_file("#{mcollective_config_path}/ssl/middleware_cert.pem") }
             it { should_not contain_file("#{mcollective_config_path}/ssl/middleware_key.pem") }
+          end
+
+          context 'true and "true"' do
+            [true, 'true',].each do |value|
+              let(:common_params) { { :server => true, :middleware_hosts => %w( foo ), :middleware_ssl => value } }
+              let(:params) { common_params }
+              it { should contain_mcollective__common__setting('plugin.activemq.pool.1.ssl').with_value('1') }
+              it { should contain_mcollective__common__setting('plugin.activemq.pool.1.ssl.fallback').with_value('0') }
+            end
           end
 
           context 'true' do
@@ -768,6 +776,15 @@ describe 'mcollective' do
           let(:params) { { :server => false, :client => true, :middleware_hosts => %w( foo ) } }
           it 'should default to false' do
             should_not contain_mcollective__common__setting('plugin.activemq.pool.1.ssl')
+          end
+
+          context 'true and "true"' do
+            [true, 'true',].each do |value|
+              let(:common_params) { { :server => true, :middleware_hosts => %w( foo ), :middleware_ssl => value } }
+              let(:params) { common_params }
+              it { should contain_mcollective__common__setting('plugin.activemq.pool.1.ssl').with_value('1') }
+              it { should contain_mcollective__common__setting('plugin.activemq.pool.1.ssl.fallback').with_value('0') }
+            end
           end
 
           context 'true' do

--- a/spec/defines/mcollective__user_spec.rb
+++ b/spec/defines/mcollective__user_spec.rb
@@ -28,11 +28,13 @@ describe 'mcollective::user' do
   end
 
   describe '#middleware_ssl' do
-    context 'true' do
-      let(:params) { default_params.merge(:middleware_ssl => true) }
-      it { should contain_file('/home/nagios/.mcollective.d/credentials/private_keys/nagios.pem') }
-      it { should contain_mcollective__user__setting('nagios plugin.activemq.pool.1.ssl.cert') }
-      it { should contain_mcollective__user__setting('nagios plugin.activemq.pool.1.ssl.cert').with_value('/home/nagios/.mcollective.d/credentials/certs/nagios.pem') }
+    context 'true and "true"' do
+      [true, 'true',].each do |value|
+        let(:params) { default_params.merge(:middleware_ssl => value) }
+        it { should contain_file('/home/nagios/.mcollective.d/credentials/private_keys/nagios.pem') }
+        it { should contain_mcollective__user__setting('nagios plugin.activemq.pool.1.ssl.cert') }
+        it { should contain_mcollective__user__setting('nagios plugin.activemq.pool.1.ssl.cert').with_value('/home/nagios/.mcollective.d/credentials/certs/nagios.pem') }
+      end
     end
 
     context 'false' do


### PR DESCRIPTION
commit 94a1facf317066cfe266412ebc7cc2a803375526
Author: Sebastian Reitenbach <sebastia@l00-bugdead-prods.de>
Date:   Tue Jun 9 20:01:17 2015 +0200

        The ruby interpreter is /usr/local/bin/ruby21, named after
           the ruby version it's used to run. I made the interpreter configurable
           instead of hardcoding another one in.
           Therefore added a ruby_interpreter parameter, that defaults to
           what was there hardcoded.
           SPEC tests added for the interpreter.

commit 91d0f2e9aa0e09f382d96aa18c69631fefdb2aef
Author: Sebastian Reitenbach <sebastia@l00-bugdead-prods.de>
Date:   Tue Jun 9 20:00:31 2015 +0200

        * there is no distinction between client and server package,
           it's just a single package. For that reason, a check is added
           around client and server package definition, checking if it
           might already be defined. Therefore added server_package and
           client_package parameters, defaulting to what was there hard-coded.
           SPECS still seems to work.

commit 1ec792560312054a1347544fce77bca8d8cab557
Author: Sebastian Reitenbach <sebastia@l00-bugdead-prods.de>
Date:   Tue Jun 9 19:56:16 2015 +0200

         * I use Hiera, to define all the gory parameters, with that there
           was trouble, getting the boolean value of middleware_ssl from there
           into the module, so had to add a check around it in the
           activemq/hosts_iteration.pp and rabbitmq/hosts_iteration.pp
           This is also the reason why I had to bump minimal required stdlib
           version from 3.2.0 to 4.2.0

first time I had to unsquash commits, and it worked without messing up with Git ;)
While there, the original pull requests, due to resetting my fork disappeared :(
Anyways, now hope that meets your expectations.

Otherwise let me know how to improve, and I'll be happy to do so.

cheers,
Sebastian