### PR TITLE
Enable package install_options

### DIFF
--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -6,7 +6,8 @@ class mcollective::client::install {
 
   if $mcollective::manage_packages {
     package { $mcollective::client_package:
-      ensure => $mcollective::version,
+      ensure          => $mcollective::version,
+      install_options => $mcollective::package_install_options,
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class mcollective (
 
   # installing packages
   $manage_packages   = true,
+  $package_install_options = [],
   $version           = 'present',
   $ruby_stomp_ensure = 'installed',
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -2,6 +2,7 @@
 define mcollective::plugin(
   $source = undef,
   $package = false,
+  $package_install_options = [],
   $type = 'agent',
   $has_client = true,
   # $client and $server are to allow for unit testing, and are considered private
@@ -14,7 +15,8 @@ define mcollective::plugin(
     # install from a package named "mcollective-${name}-${type}"
     $package_name = "mcollective-${name}-${type}"
     package { $package_name:
-      ensure => $package_ensure,
+      ensure          => $package_ensure,
+      install_options => $package_install_options
     }
 
     if $server {
@@ -25,7 +27,8 @@ define mcollective::plugin(
     # install the client package if we're installing on a $mcollective::client
     if $client and $has_client {
       package { "mcollective-${name}-client":
-        ensure => $package_ensure,
+        ensure          => $package_ensure,
+        install_options => $package_install_options
       }
     }
   }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -6,7 +6,8 @@ class mcollective::server::install {
 
   if $mcollective::manage_packages {
     package { $mcollective::server_package:
-      ensure => $mcollective::version,
+      ensure          => $mcollective::version,
+      install_options => $mcollective::package_install_options,
     }
 
     if $::osfamily == 'Debian' {
@@ -14,6 +15,7 @@ class mcollective::server::install {
       # state ruby-stomp as a dependency of mcollective, so hand specify
       package { $mcollective::ruby_stomp_package:
         ensure => $mcollective::ruby_stomp_ensure,
+        install_options => $mcollective::package_install_options,
         before => Package[$mcollective::server_package],
       }
     }


### PR DESCRIPTION
We need be able to define which repo to enable to install a package.
We expose this option with a new variable for all package resources