### PR TITLE
Lint fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :test do
   gem 'rake'
   gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.8.0'
   gem 'rspec-puppet', git: 'https://github.com/rodjek/rspec-puppet.git'
+  gem 'puppet-lint',  git: 'https://github.com/rodjek/puppet-lint.git'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'rspec-puppet-facts'

--- a/manifests/common/config/connector/activemq.pp
+++ b/manifests/common/config/connector/activemq.pp
@@ -23,7 +23,7 @@ class mcollective::common::config::connector::activemq {
 
   $indexes = mco_array_to_string(range('1', $pool_size))
   mcollective::common::config::connector::activemq::hosts_iteration { $indexes: }
-  
+
   mcollective::common::setting { 'plugin.activemq.heartbeat_interval':
     value => $mcollective::middleware_heartbeat_interval,
   }

--- a/manifests/common/config/connector/rabbitmq.pp
+++ b/manifests/common/config/connector/rabbitmq.pp
@@ -23,7 +23,7 @@ class mcollective::common::config::connector::rabbitmq {
 
   $indexes = mco_array_to_string(range('1', $pool_size))
   mcollective::common::config::connector::rabbitmq::hosts_iteration { $indexes: }
-  
+
   mcollective::common::setting { 'plugin.rabbitmq.heartbeat_interval':
     value => $mcollective::middleware_heartbeat_interval,
   }


### PR DESCRIPTION
There's not been a release of puppet-lint in over a year, so switching
to github version.  Two extra whitespace errors found and corrected.