### PR TITLE
Enabled SSL Ciphers configuration

### DIFF
--- a/manifests/common/config.pp
+++ b/manifests/common/config.pp
@@ -1,5 +1,7 @@
 #
-class mcollective::common::config {
+class mcollective::common::config (
+  $purge_libdir = true,
+) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
@@ -10,7 +12,7 @@ class mcollective::common::config {
     group        => '0',
     mode         => '0644',
     recurse      => true,
-    purge        => true,
+    purge        => $purge_libdir,
     force        => true,
     source       => [],
     sourceselect => 'all',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,7 +52,8 @@ class mcollective (
   $server_loglevel    = 'info',
   $server_daemonize   = $mcollective::defaults::server_daemonize,
   $service_name       = 'mcollective',
-  $server_package     = 'mcollective',
+  $service_ensure     = 'running',
+  $service_enable     = true,
   $ruby_stomp_package = 'ruby-stomp',
 
   # client-specific

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,9 @@ class mcollective (
   $ssl_client_certs     = 'puppet:///modules/mcollective/empty',
   $ssl_client_certs_dir = undef, # default dependent on $confdir
 
+  # ssl ciphers
+  $ssl_ciphers = undef,
+
   # Action policy settings
   $allowunconfigured    = '1',
 ) inherits mcollective::defaults {

--- a/manifests/server/config/connector/activemq/hosts_iteration.pp
+++ b/manifests/server/config/connector/activemq/hosts_iteration.pp
@@ -9,5 +9,11 @@ define mcollective::server::config::connector::activemq::hosts_iteration {
     mcollective::server::setting { "plugin.activemq.pool.${name}.ssl.key":
       value => "${mcollective::confdir}/server_private.pem",
     }
+
+    if ! empty( $mcollective::ssl_ciphers ) {
+      mcollective::server::setting { "plugin.activemq.pool.${name}.ssl.ciphers":
+        value => $mcollective::ssl_ciphers,
+      }
+    }
   }
 }

--- a/manifests/server/config/connector/rabbitmq/hosts_iteration.pp
+++ b/manifests/server/config/connector/rabbitmq/hosts_iteration.pp
@@ -9,5 +9,11 @@ define mcollective::server::config::connector::rabbitmq::hosts_iteration {
     mcollective::server::setting { "plugin.rabbitmq.pool.${name}.ssl.key":
       value => "${mcollective::confdir}/server_private.pem",
     }
+
+    if ! empty( $mcollective::ssl_ciphers ) {
+      mcollective::server::setting { "plugin.rabbitmq.pool.${name}.ssl.ciphers":
+        value => $mcollective::ssl_ciphers,
+      }
+    }
   }
 }

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -32,14 +32,14 @@ class mcollective::server::config::factsource::yaml (
   if $yaml_fact_cron {
     if versioncmp($::facterversion, '3.0.0') >= 0 {
       cron { 'refresh-mcollective-metadata':
-        command     => "facter --yaml >${yaml_fact_path_real} 2>&1",
+        command     => "facter -p --yaml >${yaml_fact_path_real} 2>&1",
         environment => 'PATH=/opt/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         user        => 'root',
         minute      => $cron_minutes,
       }
       exec { 'create-mcollective-metadata':
         path    => "/opt/puppet/bin:/opt/puppetlabs/bin:${::path}",
-        command => "facter --yaml >${yaml_fact_path_real} 2>&1",
+        command => "facter -p --yaml >${yaml_fact_path_real} 2>&1",
         creates => $yaml_fact_path_real,
       }
     } else {

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -5,7 +5,7 @@ class mcollective::server::service {
   }
 
   service { $mcollective::service_name:
-    ensure => 'running',
-    enable => true,
+    ensure => $mcollective::service_ensure,
+    enable => $mcollective::service_enable,
   }
 }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -16,6 +16,7 @@ define mcollective::user(
   $middleware_ssl = $mcollective::middleware_ssl,
   $securityprovider = $mcollective::securityprovider,
   $connector = $mcollective::connector,
+  $ssl_ciphers = $mcollective::ssl_ciphers,
 ) {
   file { [
     "${homedir}/.mcollective.d",
@@ -102,6 +103,7 @@ define mcollective::user(
       homedir        => $homedir,
       connector      => $connector,
       middleware_ssl => $middleware_ssl,
+      ssl_ciphers    => $ssl_ciphers,
       order          => '60',
     }
   }

--- a/manifests/user/connector.pp
+++ b/manifests/user/connector.pp
@@ -6,6 +6,7 @@ define mcollective::user::connector(
   $order,
   $connector,
   $middleware_ssl,
+  $ssl_ciphers,
 ) {
   $i = regsubst($title, "^${username}_", '')
 
@@ -29,6 +30,15 @@ define mcollective::user::connector(
       username => $username,
       order    => $order,
       value    => "${homedir}/.mcollective.d/credentials/private_keys/${callerid}.pem",
+    }
+
+    if ! empty( $ssl_ciphers ) {
+      mcollective::user::setting { "${username} plugin.${connector}.pool.${i}.ssl.ciphers":
+        setting  => "plugin.${connector}.pool.${i}.ssl.ciphers",
+        username => $username,
+        order    => $order,
+        value    => $ssl_ciphers,
+      }
     }
   }
 }


### PR DESCRIPTION
I've added the possibility to configure the ssl ciphers. I've encountered an issue while upgrading from 3.8.4 to 4.x

```
error 2015/11/19 10:30:03: rabbitmq.rb:45:in `on_ssl_connectfail' SSL session creation with stomp+ssl://mcollective@puppet.example.lan:61614 failed: SSL_connect SYSCALL returned=5 errno=0 state=SSLv2/v3 read server hello A
````

Had to fix it with :

`mcollective::ssl_ciphers: AES256-SHA256`