### PR TITLE
Core_libdir does not exist in mcollective 2.8 and later

### DIFF
--- a/lib/facter/mco_version.rb
+++ b/lib/facter/mco_version.rb
@@ -1,0 +1,10 @@
+Facter.add('mco_version') do
+  setcode do
+    begin
+      require 'mcollective'
+      MCollective::VERSION
+    rescue LoadError
+      nil
+    end
+  end
+end

--- a/manifests/common/config.pp
+++ b/manifests/common/config.pp
@@ -35,8 +35,14 @@ class mcollective::common::config {
     },
   }
 
+  $libdir = $::mcollective::core_libdir ? {
+    undef   => $::mcollective::site_libdir,
+    ''      => $::mcollective::site_libdir,
+    default => "${::mcollective::site_libdir}:${::mcollective::core_libdir}"
+  }
+
   mcollective::common::setting { 'libdir':
-    value => "${mcollective::site_libdir}:${mcollective::core_libdir}",
+    value => $libdir,
   }
 
   mcollective::common::setting { 'connector':

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -7,7 +7,7 @@
 class mcollective::defaults {
   if versioncmp($::puppetversion, '4') < 0 {
     $confdir = '/etc/mcollective'
-    $core_libdir = $::osfamily ? {
+    $_core_libdir = $::osfamily ? {
       'Debian' => '/usr/share/mcollective/plugins',
       default  => '/usr/libexec/mcollective',
     }
@@ -21,8 +21,19 @@ class mcollective::defaults {
     }
   } else {
     $confdir     = '/etc/puppetlabs/mcollective'
-    $core_libdir = '/opt/puppetlabs/mcollective/plugins'
+    $_core_libdir = '/opt/puppetlabs/mcollective/plugins'
     $site_libdir = '/opt/puppetlabs/mcollective'
+  }
+
+  # Since mcollective version 2.8, there is no core libdir
+  # https://docs.puppetlabs.com/mcollective/releasenotes.html#libdirloadpath-changes-and-core-plugins
+  $mco_assumed_version = '2.8.5'
+
+  $_mco_version = pick($::mco_version, $mco_assumed_version)
+  if versioncmp($_mco_version, '2.8') >= 0 {
+    $core_libdir = undef
+  } else {
+    $core_libdir = $_core_libdir
   }
 
   if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '14.10') <= 0){

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -621,6 +621,17 @@ describe 'mcollective' do
 
   describe '#core_libdir' do
     context 'default' do
+      it { should contain_mcollective__common__setting('libdir').with_value("#{mcollective_site_libdir_path}") }
+    end
+
+    context 'when mco_version < 2.8' do
+      let :facts do
+        {
+          :puppetversion => Puppet.version,
+          :facterversion => Facter.version,
+          :mco_version   => '2.7.0'
+        }
+      end
       it { should contain_mcollective__common__setting('libdir').with_value("#{mcollective_site_libdir_path}:#{mcollective_core_libdir_path}") }
     end
 
@@ -633,13 +644,24 @@ describe 'mcollective' do
   describe '#site_libdir' do
     context 'default' do
       it { should contain_file(mcollective_site_libdir_path).with_mode('0644') }
+      it { should contain_mcollective__common__setting('libdir').with_value("#{mcollective_site_libdir_path}") }
+    end
+
+    context 'when mco_version < 2.8' do
+      let :facts do
+        {
+          :puppetversion => Puppet.version,
+          :facterversion => Facter.version,
+          :mco_version   => '2.7.0'
+        }
+      end
       it { should contain_mcollective__common__setting('libdir').with_value("#{mcollective_site_libdir_path}:#{mcollective_core_libdir_path}") }
     end
 
     context 'set' do
       let(:params) { { :site_libdir => '/usr/local/fishy/fishy' } }
       it { should contain_file('/usr/local/fishy/fishy') }
-      it { should contain_mcollective__common__setting('libdir').with_value("/usr/local/fishy/fishy:#{mcollective_core_libdir_path}") }
+      it { should contain_mcollective__common__setting('libdir').with_value('/usr/local/fishy/fishy') }
     end
   end
 


### PR DESCRIPTION
This PR should address an issue brought up on #puppet-community IRC
```
    "warn 2015/12/10 11:06:52: config.rb:148:in `block in loadconfig' Cannot find libdir: /usr/share/mcollective/plugins"
```

Needs testing!