### PR TITLE
fix rubocop complaint

### DIFF
--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -294,7 +294,6 @@ describe 'mcollective' do
         end
 
         describe '#fact_cron_splay' do
-
           let(:facts) do
             {
               :puppetversion => Puppet.version,


### PR DESCRIPTION
I noticed this [here](https://travis-ci.org/voxpupuli/puppet-mcollective/jobs/106630279):
`spec/classes/mcollective_spec.rb:297:1: C: Extra empty line detected at block body beginning.`