### PR TITLE
Remove unneeded puppetlabs-concat dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,6 @@
 ---
 fixtures:
   repositories:
-    concat:
-      repo: 'https://github.com/puppetlabs/puppetlabs-concat.git'
-      ref: '1.0.4'
     datacat:
       repo: 'https://github.com/richardc/puppet-datacat.git'
       ref: '0.5.0'

--- a/metadata.json
+++ b/metadata.json
@@ -20,10 +20,6 @@
       "version_requirement": ">= 0.6.2 < 1.0.0"
     },
     {
-      "name": "puppetlabs/concat",
-      "version_requirement": "1.x"
-    },
-    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">=4.2.0 < 5.0.0"
     }


### PR DESCRIPTION
As discussed in https://github.com/voxpupuli/puppet-mcollective/pull/288 the dependency on puppetlabs-concat is not necessary anymore.
=> Remove it.