### PR TITLE
Re-add FQDN stubbing for more randomness

### DIFF
--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -324,6 +324,7 @@ describe 'mcollective' do
               puppetversion: Puppet.version,
               facterversion: Facter.version,
               macaddress: '00:00:00:26:28:8a',
+              fqdn: 'somereallylongfqdnthatleadstobetterrandomnumbers.example.com',
               osfamily: 'RedHat',
               operatingsystem: 'CentOS',
               path: ['/usr/bin', '/usr/sbin'],


### PR DESCRIPTION
* Was causing issues with transient failures in Travis (possibly because Travis machines don't have distinct enough FQDN)
