### PR TITLE
Use factsource and plugin.yaml regardless of $yaml_fact_cron.   Make 1.8.7 compatible.

### DIFF
--- a/lib/puppet/parser/functions/mco_array_to_string.rb
+++ b/lib/puppet/parser/functions/mco_array_to_string.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # vim: set sw=2 sts=2 et tw=80 :
-Puppet::Parser::Functions.newfunction(:mco_array_to_string, type: :rvalue) do |args|
+Puppet::Parser::Functions.newfunction(:mco_array_to_string, :type => :rvalue) do |args|
   unless args[0].is_a? Array
     raise ArgumentError, "Expected an array, but got a #{args[0].class}"
   end

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -65,11 +65,12 @@ class mcollective::server::config::factsource::yaml (
         require => File["${mcollective::site_libdir}/refresh-mcollective-metadata"],
       }
     }
-    mcollective::server::setting { 'factsource':
-      value => 'yaml',
-    }
-    mcollective::server::setting { 'plugin.yaml':
-      value => $yaml_fact_path_real,
-    }
+  }
+
+  mcollective::server::setting { 'factsource':
+    value => 'yaml',
+  }
+  mcollective::server::setting { 'plugin.yaml':
+    value => $yaml_fact_path_real,
   }
 }


### PR DESCRIPTION
Previously this worked this way.  I didn't track down where it changed, but I think that factsource should be set regardless (especially?) if $yaml_fact_cron is false.  We generate our own fact file because we also have some variables (not actual facts) we want in there.

This gets us back into a working state, and I think it's how people that don't use the cron would prefer it?

I also changed mco_array_to_string.rb to be Ruby 1.8.7 friendly.