### PR TITLE
Use factsource and plugin.yaml regardless of $yaml_fact_cron.

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -65,11 +65,12 @@ class mcollective::server::config::factsource::yaml (
         require => File["${mcollective::site_libdir}/refresh-mcollective-metadata"],
       }
     }
-    mcollective::server::setting { 'factsource':
-      value => 'yaml',
-    }
-    mcollective::server::setting { 'plugin.yaml':
-      value => $yaml_fact_path_real,
-    }
+  }
+
+  mcollective::server::setting { 'factsource':
+    value => 'yaml',
+  }
+  mcollective::server::setting { 'plugin.yaml':
+    value => $yaml_fact_path_real,
   }
 }


### PR DESCRIPTION
Previously this worked this way. I didn't track down where it changed, but I think that factsource should be set regardless (especially?) if $yaml_fact_cron is false. We generate our own fact file because we also have some variables (not actual facts) we want in there.

This gets us back into a working state, and I think it's how people that don't use the cron would prefer it?
