### PR TITLE
Avoid compilation failure with strict_variables=true

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -31,7 +31,10 @@ class mcollective::defaults {
   # https://docs.puppetlabs.com/mcollective/releasenotes.html#libdirloadpath-changes-and-core-plugins
   $mco_assumed_version = '2.8.5'
 
-  $_mco_version = pick_default($::mco_version, $mco_assumed_version)
+  $_mco_version = defined('$mco_version') ? {
+    true    => $::mco_version,
+    default => $mco_assumed_version,
+  }
   if versioncmp($_mco_version, '2.8') >= 0 {
     $core_libdir = undef
   } else {


### PR DESCRIPTION
When `strict_variables` is on and mcollective has yet to be installed, `mco_version` isn't defined, so referring to it here breaks compilation. The fix here uses a pattern used by puppetlabs-apt.

Seeing as this is a very minor fix and testing Puppet modules is an art I'm totally unfamiliar with, I haven't changed any tests as part of this commit. I hope that's not too much of a problem.