### PR TITLE
fix _securityprovider call in user.pp

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -122,7 +122,7 @@ define mcollective::user(
       }
     }
     # Preserve old behavior
-    elsif $securityprovider == 'ssl' {
+    elsif $_securityprovider == 'ssl' {
       file { $private_path:
         ensure => 'file',
         source =>  $_ssl_server_private,
@@ -133,7 +133,7 @@ define mcollective::user(
     }
   }
 
-  if $securityprovider == 'ssl' {
+  if $_securityprovider == 'ssl' {
     $cert_path = "${homedir_real}/.mcollective.d/credentials/certs/${callerid}.pem"
     if $certificate {
       file { $cert_path:
@@ -186,7 +186,7 @@ define mcollective::user(
     }
   }
 
-  if $securityprovider == 'sshkey' {
+  if $_securityprovider == 'sshkey' {
     $public_path = "${homedir_real}/.mcollective.d/credentials/public_keys/${callerid}.pem"
     if $public_key {
       file { $public_path:


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

use _securityprovider, otherwise files and settings won't be set if inherited from mcollective::securityprovider