### PR TITLE
Use puppet facts instead of facter -p

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -28,7 +28,7 @@ class mcollective::server::config::factsource::yaml (
   if $yaml_fact_cron {
     if versioncmp($::facterversion, '3.0.0') >= 0 {
       cron { 'refresh-mcollective-metadata':
-        command     => "facter -p --yaml >${yaml_fact_path_real} 2>&1",
+        command     => "puppet facts --render-as yaml >${yaml_fact_path_real} 2>&1",
         environment => 'PATH=/opt/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         user        => 'root',
         minute      => $cron_minutes,


### PR DESCRIPTION
`facter -p` is officially deprecated and `puppet facts` actually returns more keys (including obsolete mapped keys, such as `operatingsystem` and `osfamily`).