### PR TITLE
Make client middleware cert configurable

### DIFF
--- a/manifests/common/config/connector/activemq/hosts_iteration.pp
+++ b/manifests/common/config/connector/activemq/hosts_iteration.pp
@@ -36,11 +36,11 @@ define mcollective::common::config::connector::activemq::hosts_iteration {
     }
 
     mcollective::common::setting { "plugin.activemq.pool.${name}.ssl.cert":
-      value => '/etc/mcollective/server_public.pem',
+      value => $::mcollective::middleware_ssl_cert_path,
     }
 
     mcollective::common::setting { "plugin.activemq.pool.${name}.ssl.key":
-      value => '/etc/mcollective/server_private.pem',
+      value => $::mcollective::middleware_ssl_key_path,
     }
 
     mcollective::common::setting { "plugin.activemq.pool.${name}.ssl.ca":

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -896,6 +896,9 @@ describe 'mcollective' do
 
           it 'defaults to false' do
             is_expected.not_to contain_mcollective__common__setting('plugin.activemq.pool.1.ssl')
+            is_expected.not_to contain_file("#{mcollective_config_path}/ssl/middleware_ca.pem")
+            is_expected.not_to contain_file("#{mcollective_config_path}/ssl/middleware_cert.pem")
+            is_expected.not_to contain_file("#{mcollective_config_path}/ssl/middleware_key.pem")
           end
 
           context 'true and "true"' do
@@ -905,6 +908,12 @@ describe 'mcollective' do
 
               it { is_expected.to contain_mcollective__common__setting('plugin.activemq.pool.1.ssl').with_value('1') }
               it { is_expected.to contain_mcollective__common__setting('plugin.activemq.pool.1.ssl.fallback').with_value('0') }
+              it { is_expected.to contain_mcollective__common__setting('plugin.activemq.pool.1.ssl.ca').with_value("#{mcollective_config_path}/ssl/middleware_ca.pem") }
+              it { is_expected.to contain_mcollective__common__setting('plugin.activemq.pool.1.ssl.cert').with_value("#{mcollective_config_path}/ssl/middleware_cert.pem") }
+              it { is_expected.to contain_mcollective__common__setting('plugin.activemq.pool.1.ssl.key').with_value("#{mcollective_config_path}/ssl/middleware_key.pem") }
+              it { is_expected.to contain_file("#{mcollective_config_path}/ssl/middleware_ca.pem") }
+              it { is_expected.to contain_file("#{mcollective_config_path}/ssl/middleware_cert.pem") }
+              it { is_expected.to contain_file("#{mcollective_config_path}/ssl/middleware_key.pem") }
             end
           end
 


### PR DESCRIPTION
Use

$::mcollective::middleware_ssl_cert_path
$::mcollective::middleware_ssl_key_path

instead of hard coded path for common (client)

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
