### PR TITLE
Remove Yaml class serialization information

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -28,7 +28,7 @@ class mcollective::server::config::factsource::yaml (
   if $yaml_fact_cron {
     if versioncmp($::facterversion, '3.0.0') >= 0 {
       cron { 'refresh-mcollective-metadata':
-        command     => "puppet facts --render-as yaml >${yaml_fact_path_real} 2>&1",
+        command     => "puppet facts --render-as yaml |sed 's%!ruby/object:Puppet::Node::Facts%%g' >${yaml_fact_path_real} 2>&1",
         environment => 'PATH=/opt/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         user        => 'root',
         minute      => $cron_minutes,


### PR DESCRIPTION
`puppet facts --render-as yaml` returns a yaml file which is the
serialized version of the object:Puppet::Node::Facts.

Mcollective parses this yaml and tries to make a hash out of it.
We get an error:

  ```ERROR -- : yaml_facts.rb:31:in `rescue in block in
  load_facts_from_source' Failed to load yaml facts from
  /etc/puppetlabs/mcollective/facts.yaml: TypeError: no implicit
  conversion of Puppet::Node::Facts into HasH```

So we are remove that class information out of the yaml to be able to
serialize it as a ruby hash.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
