### PR TITLE
use different delimiter for the sed at the puppet facts cronjob

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -28,7 +28,7 @@ class mcollective::server::config::factsource::yaml (
   if $yaml_fact_cron {
     if versioncmp($::facterversion, '3.0.0') >= 0 {
       cron { 'refresh-mcollective-metadata':
-        command     => "puppet facts --render-as yaml |sed 's%!ruby/object:Puppet::Node::Facts%%g' >${yaml_fact_path_real} 2>&1",
+        command     => "puppet facts --render-as yaml |sed 's#!ruby/object:Puppet::Node::Facts##g' >${yaml_fact_path_real} 2>&1",
         environment => 'PATH=/opt/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         user        => 'root',
         minute      => $cron_minutes,


### PR DESCRIPTION
Using '%' as delimiter for the sed at the 'puppet facts' cronjob ends up
to the following error:

Subject: Cron <root@server> puppet facts --render-as yaml |sed 's

/bin/sh: -c: line 0: unexpected EOF while looking for matching `''
/bin/sh: -c: line 1: syntax error: unexpected end of file

Replacing the delimiter with '#' instead works fine