### PR TITLE
Add show_diff set to false for files storing passwords or private keys

### DIFF
--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -18,11 +18,12 @@ class mcollective::client::config (
   }
   else {
     datacat { 'mcollective::client':
-      owner    => $owner,
-      group    => $group,
-      mode     => $mode,
-      path     => $mcollective::client_config_file_real,
-      template => 'mcollective/settings.cfg.erb',
+      owner     => $owner,
+      group     => $group,
+      mode      => $mode,
+      path      => $mcollective::client_config_file_real,
+      show_diff => false,
+      template  => 'mcollective/settings.cfg.erb',
     }
   }
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -5,11 +5,12 @@ class mcollective::server::config {
   }
 
   datacat { 'mcollective::server':
-    owner    => 'root',
-    group    => '0',
-    mode     => '0400',
-    path     => $mcollective::server_config_file_real,
-    template => 'mcollective/settings.cfg.erb',
+    owner     => 'root',
+    group     => '0',
+    mode      => '0400',
+    path      => $mcollective::server_config_file_real,
+    show_diff => false,
+    template  => 'mcollective/settings.cfg.erb',
   }
 
   mcollective::server::setting { 'classesfile':
@@ -52,10 +53,11 @@ class mcollective::server::config {
     }
 
     file { $::mcollective::middleware_ssl_key_path:
-      owner  => 'root',
-      group  => '0',
-      mode   => '0400',
-      source => $::mcollective::middleware_ssl_key_real,
+      owner     => 'root',
+      group     => '0',
+      mode      => '0400',
+      show_diff => false,
+      source    => $::mcollective::middleware_ssl_key_real,
     }
 
     file { $::mcollective::middleware_ssl_cert_path:
@@ -77,10 +79,11 @@ class mcollective::server::config {
     }
 
     file { $::mcollective::ssl_server_private_path:
-      owner  => 'root',
-      group  => '0',
-      mode   => '0400',
-      source => $::mcollective::ssl_server_private,
+      owner     => 'root',
+      group     => '0',
+      mode      => '0400',
+      show_diff => false,
+      source    => $::mcollective::ssl_server_private,
     }
 
   }


### PR DESCRIPTION
For security reason. Currently, when changes are made, puppet stores in reports and logs mcollective passwords and private keys.