### PR TITLE
Up requirement of stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 6.0.0"
+      "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
   "description": "MCollective Puppet Module",


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Raises stdlib requirement to < 7.0.0

#### This Pull Request (PR) fixes the following issues
The Puppet Forge module Stdlib 6.0.0 was released in May 2019, and appears to have no breaking changes. This should be merged so that users of this module can use the latest stdlib version.